### PR TITLE
update the README to link the the contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Let us know that you would like to be a maintainer in the Slack channel *#algori
 
 The success of our vision to bring knowledge offline** depends on you. Even a small contribution helps. All forms of contribution are highly welcomed and valued. 
 
-When you contribute, your name with a link (if available) is added to our [contributors list]().
+When you contribute, your name with a link (if available) is added to our [contributors list](https://github.com/OpenGenus/cosmos/wiki/contributors).
 
 # License
 


### PR DESCRIPTION
The links to the contributors list and the maintainers list were missing. I added the contributors link, but did not know where the other one was located.