### PR TITLE
Correcting php function names to follow the coding standards.

### DIFF
--- a/code/sorting/bubble_sort/bubble_sort.php
+++ b/code/sorting/bubble_sort/bubble_sort.php
@@ -2,7 +2,7 @@
 
 $array = array(0,1,6,7,6,3,4,2);
 
-function bubble_Sort($array)
+function bubble_sort($array)
 {
 	do
 	{

--- a/code/sorting/selection_sort/SelectionSort.php
+++ b/code/sorting/selection_sort/SelectionSort.php
@@ -1,6 +1,6 @@
 <?php
 // Part of Cosmos by OpenGenus Foundation
-function selectionSort($arr) {
+function selection_sort($arr) {
     $n = count($arr);
 
     foreach ($arr as $k => $el) {
@@ -24,6 +24,6 @@ function selectionSort($arr) {
 $test = [1, 3, 43, 2, 14, 53, 12, 87, 33];
 
 print_r($test);
-$sorted = selectionSort($test);
+$sorted = selection_sort($test);
 
 print_r($sorted);


### PR DESCRIPTION
Corrected some function names for PHP, following php.net coding standards, which can be found here: http://git.php.net/?p=php-src.git;a=blob_plain;f=CODING_STANDARDS;hb=HEAD

> 1.  Function names for user-level functions should be enclosed with in
>     the PHP_FUNCTION() macro. **They should be in lowercase, with words
>     underscore delimited**, with care taken to minimize the letter count.