### PR TITLE
Fix the memoized version to use the cache for n > 1

### DIFF
--- a/code/mathematical-algorithms/fibonacci_number/fibonacci.rb
+++ b/code/mathematical-algorithms/fibonacci_number/fibonacci.rb
@@ -6,13 +6,11 @@ def fibonacci(n)
   end
 end
 
-def fibonacci_memoized(n)
-  cache = { 0 => 0, 1 => 1 }
-  if cache.has_key?(n)
-    return cache.fetch(n)
-  end
-  cache[n] = fibonacci_memoized(n-2) + fibonacci_memoized(n-1)
-  cache[n]
+def fibonacci_memoized(n, cache=nil)
+  cache ||= { 0 => 0, 1 => 1 }
+  cache[n] = fibonacci_memoized(n-2, cache) + fibonacci_memoized(n-1, cache) unless cache.key?(n)
+
+  cache.fetch(n)
 end
 
 n = ARGV[0].to_i


### PR DESCRIPTION
Currently the memoized version declares a new cache on every single step, so the cache is only used for values 0 and 1.  I've illustrated this with a RubyFiddle - http://rubyfiddle.com/riddles/60df0/1 - you can see the app never reports 'cache hit'.  With this updated version - which you can see with another RubyFiddle, http://rubyfiddle.com/riddles/9d409/2 - the cache is used properly.

It's also more semantic to use `Hash#key?` instead of `Hash#has_key?` in Ruby 1.9 and onwards.