### PR TITLE
Add formatting guide

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,6 @@ matrix:
         - standard
     - language: go
       go: 1.7
-      install:
+      install: true
       script:
         - gofmt -d .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+sudo: false
+
+matrix:
+  include:
+    - language: python
+      python:
+        - 2.7
+        - 3.3
+        - 3.4
+        - 3.5
+        - 3.6
+      install:
+        - pip install flake8
+      script:
+        - flake8
+    - language: node_js
+      node_js: 7
+      install:
+        - npm install standard
+      script:
+        - standard
+    - language: go
+      go: 1.7
+      script:
+        - gofmt -d .

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,7 @@ matrix:
   include:
     - language: python
       python:
-        - 2.7
-        - 3.3
-        - 3.4
         - 3.5
-        - 3.6
       install:
         - pip install flake8
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,6 @@ matrix:
         - standard
     - language: go
       go: 1.7
+      install:
       script:
         - gofmt -d .

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ sudo: false
 matrix:
   include:
     - language: python
-      python:
-        - 3.5
+      python: 3.5
       install:
         - pip install flake8
       script:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing
+
+The repo is organized into directories each with their own classification of problems.
+
+Following is the high-level structure of cosmos:
+* Backtracking	
+* Bit manipulation
+* Computational geometry
+* Data structures
+* Divide conquer
+* Dynamic programming
+* Graph algorithms
+* Greedy algorithms
+* Mathematical algorithms	
+* Randomized algorithms	
+* Search 
+* Sorting	
+* String algorithms
+* Unclassified 👻
+
+Inside each, there will be folders with individual types of algorithms/data structures solved in different languages.
+A folder may contain Python, Javascript, C++, Java, Golang etc. code all in the same folder.
+
+## We welcome PRs!
+
+You are welcome to submit PRs for additions to any part of the repo. Just remember to adhere to the code standards and directory structure depending on what language you are using.
+
+## Code standards
+
+Code submitted must adhere to a standard for the language. Currently, the following standards are implemented:
+
+* Python - PEP8
+* Javascript - Standard JS
+* Golang - gofmt
+* Java - [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)
+* C++ - [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html)


### PR DESCRIPTION
Fixes #840. Currently lints for Python, JS and Go and standards for Java and C++. Need someone with more experience with languages other than Python, JS, and Go to comment on which style would work best. 

Some files have syntax errors as found by the linters, and a branch with fixed and formatted files is available here: https://github.com/kusti8/cosmos/tree/fixed-files

It would be a large undertaking and there are a lot of files that still need manual intervention, but it would be best to format all of them to a standard and these languages have agreed upon standards for their styling.

Welcome to suggestions and edits!