### PR TITLE
Fix bubble sort example in Go

### DIFF
--- a/code/sorting/bubble_sort/bubble_sort.go
+++ b/code/sorting/bubble_sort/bubble_sort.go
@@ -1,25 +1,15 @@
 /* Part of Cosmos by OpenGenus Foundation */
 package main
 
-import (
-	"algoutils"
-	"fmt"
-)
-
-func swap(arrayzor []int, i, j int) {
-	tmp := arrayzor[j]
-	arrayzor[j] = arrayzor[i]
-	arrayzor[i] = tmp
-}
+import "fmt"
 
 func bubbleSort(arrayzor []int) {
-
 	swapped := true
 	for swapped {
 		swapped = false
 		for i := 0; i < len(arrayzor)-1; i++ {
 			if arrayzor[i+1] < arrayzor[i] {
-				algoutils.Swap(arrayzor, i, i+1)
+				arrayzor[i], arrayzor[i+1] = arrayzor[i+1], arrayzor[i]
 				swapped = true
 			}
 		}
@@ -27,7 +17,6 @@ func bubbleSort(arrayzor []int) {
 }
 
 func main() {
-
 	arrayzor := []int{1, 6, 2, 4, 9, 0, 5, 3, 7, 8}
 	fmt.Println("Unsorted array: ", arrayzor)
 	bubbleSort(arrayzor)


### PR DESCRIPTION
There is no package called `algoutils` in standard libraries, also removed swap function since there are multiple assignments in GO.