### PR TITLE
Bit manipulation for looping over all subset masks of bits

### DIFF
--- a/code/bit-manipulation/subset_generation/subset_mask_generator.cpp
+++ b/code/bit-manipulation/subset_generation/subset_mask_generator.cpp
@@ -1,0 +1,23 @@
+#include <iostream>
+
+typedef unsigned long long ll;
+
+//Loops over all subsets of the bits in to_mask. Except to_mask itself
+//For test input (111)
+//110
+//101
+//100
+//010
+//001
+//000
+
+void generate_masks(ll to_mask){
+  for(int mask = to_mask; mask;){
+    --mask &= to_mask;
+    std::cout << mask << std::endl;
+  }
+}
+
+int main(){
+  generate_masks(7);
+}


### PR DESCRIPTION
Added bit manipulation trick for looping over all subset of bits in an input.

NOTE: there is no issue for this so I don't know if you want this or not.