### PR TITLE
Add memoization to shortest common supersequence solution

### DIFF
--- a/code/dynamic_programming/shortest_common_supersequence/shortest_common_supersequence.cpp
+++ b/code/dynamic_programming/shortest_common_supersequence/shortest_common_supersequence.cpp
@@ -1,4 +1,5 @@
-#include <bits/stdc++.h>
+#include <iostream>
+#include <cstring>
 
 using namespace std;
 
@@ -38,7 +39,7 @@ int main()
 {
     string X = "ABCBDAB", Y = "BDCABA";
 
-    cout << "The length of shortest Common supersequence is "
+    cout << "The length of shortest common supersequence is "
          << findSCSLength(X, Y) << '\n';
 
     return 0;

--- a/code/dynamic_programming/shortest_common_supersequence/shortest_common_supersequence.cpp
+++ b/code/dynamic_programming/shortest_common_supersequence/shortest_common_supersequence.cpp
@@ -1,32 +1,45 @@
 #include <bits/stdc++.h>
+
 using namespace std;
 
-// Function to find length of shortest Common supersequence of
-// sequences X[0..m-1] and Y[0..n-1]
-int SCSLength(string X, string Y, int m, int n)
+const int MAX = 1010;
+
+int memo[MAX][MAX]; // used for memoization
+
+// Function to find length of shortest common supersequence
+// between sequences X[0..m-1] and Y[0..n-1]
+int SCSLength(string& X, string& Y, int m, int n)
 {
 	// if we have reached the end of either sequence, return
 	// length of other sequence
 	if (m == 0 || n == 0)
 		return n + m;
 
+    // if we have already computed this state
+    if(memo[m-1][n-1] > -1) return memo[m-1][n-1];
+
 	// if last character of X and Y matches
 	if (X[m - 1] == Y[n - 1])
-		return SCSLength(X, Y, m - 1, n - 1) + 1;
+		return memo[m-1][n-1] = SCSLength(X, Y, m - 1, n - 1) + 1;
 	else
 	// else if last character of X and Y don't match
-		return min(SCSLength(X, Y, m, n - 1) + 1,
-					SCSLength(X, Y, m - 1, n) + 1);
+        return memo[m-1][n-1] = 1 + min(SCSLength(X, Y, m, n - 1),
+                                        SCSLength(X, Y, m - 1, n));
+}
+
+// helper function
+int findSCSLength(string& X, string& Y) {
+    memset(memo, -1, sizeof memo);
+    return SCSLength(X, Y, X.length(), Y.length());
 }
 
 // main function
 int main()
 {
 	string X = "ABCBDAB", Y = "BDCABA";
-	int m = X.length(), n = Y.length();
 
-	cout << "The length of shortest Common supersequence is "
-			<< SCSLength(X, Y, m, n);
+    cout << "The length of shortest Common supersequence is "
+         << findSCSLength(X, Y) << '\n';
 
 	return 0;
 }

--- a/code/dynamic_programming/shortest_common_supersequence/shortest_common_supersequence.cpp
+++ b/code/dynamic_programming/shortest_common_supersequence/shortest_common_supersequence.cpp
@@ -10,19 +10,19 @@ int memo[MAX][MAX]; // used for memoization
 // between sequences X[0..m-1] and Y[0..n-1]
 int SCSLength(string& X, string& Y, int m, int n)
 {
-	// if we have reached the end of either sequence, return
-	// length of other sequence
-	if (m == 0 || n == 0)
-		return n + m;
+    // if we have reached the end of either sequence, return
+    // length of other sequence
+    if (m == 0 || n == 0)
+        return n + m;
 
     // if we have already computed this state
     if(memo[m-1][n-1] > -1) return memo[m-1][n-1];
 
-	// if last character of X and Y matches
-	if (X[m - 1] == Y[n - 1])
-		return memo[m-1][n-1] = SCSLength(X, Y, m - 1, n - 1) + 1;
-	else
-	// else if last character of X and Y don't match
+    // if last character of X and Y matches
+    if (X[m - 1] == Y[n - 1])
+        return memo[m-1][n-1] = SCSLength(X, Y, m - 1, n - 1) + 1;
+    else
+    // else if last character of X and Y don't match
         return memo[m-1][n-1] = 1 + min(SCSLength(X, Y, m, n - 1),
                                         SCSLength(X, Y, m - 1, n));
 }
@@ -36,10 +36,10 @@ int findSCSLength(string& X, string& Y) {
 // main function
 int main()
 {
-	string X = "ABCBDAB", Y = "BDCABA";
+    string X = "ABCBDAB", Y = "BDCABA";
 
     cout << "The length of shortest Common supersequence is "
          << findSCSLength(X, Y) << '\n';
 
-	return 0;
+    return 0;
 }


### PR DESCRIPTION
Updated C++ solution to use memoization instead of naive recursion. I also substituted
 the `bits/stdc++.h` header as it is not available in all compilers.