### PR TITLE
Fix polygon area

### DIFF
--- a/code/computational_geometry/area_of_polygon/area_of_polygon.cpp
+++ b/code/computational_geometry/area_of_polygon/area_of_polygon.cpp
@@ -1,3 +1,4 @@
+#include <cmath>
 #include <iostream>
 typedef std::pair<double, double> point;
 
@@ -9,7 +10,7 @@ point points[size];
 #define y second
 
 double calcArea(point a, point b, point c) {
-  return abs( (a.first - b.first) * (c.second - b.second) - (a.second - b.second) * (c.first - b.first) ) / 2;
+  return ((a.first - b.first) * (c.second - b.second) - (a.second - b.second) * (c.first - b.first)) / 2;
 }
 
 int main () {
@@ -26,5 +27,5 @@ int main () {
     answer += calcArea(points[0], points[i - 1], points[i]);
   }
 
-  std::cout << answer;
+  std::cout << abs(answer);
 }


### PR DESCRIPTION
Since we remove `abs` from the triangle area calculation and use the signed area, this method also works for non-convex polygons.
For example, for polygon
```
0 0
20 20
40 0
20 10
```
the old code returned 600, but the new one returns 200 (correct value, can be checked like `(20 * 0 - 40 * 20) / 2`).