### PR TITLE
Fixed spelling mistake with Heap README.md link

### DIFF
--- a/code/sorting/heap_sort/README.md
+++ b/code/sorting/heap_sort/README.md
@@ -6,7 +6,7 @@ Heap sort is a comparison based sorting algorithm. There are two main parts to t
 
 Heap Sort uses a heap to sort the given elements. It is a simple and efficient sorting algorithm that runs in O(n log n).
 
-[Heap implementation](https://github.com/OpenGenus/cosmos/tree/master/code/data_structures/Heap)
+[Heap implementation](https://github.com/OpenGenus/cosmos/tree/master/code/data_structures/heap)
 
 ## Procedure
 1. Build a heap with the elements you want to sort.


### PR DESCRIPTION
**Fixes dead link:** #[I fixed a dead link in a the heap_sort  sorting  README.md was showing a 404]

**Changes:**
[Spelling mistake on URL.]
