### PR TITLE
coprime_numbers: simplify go implementation

### DIFF
--- a/code/mathematical-algorithms/coprime_numbers/coprime_numbers.go
+++ b/code/mathematical-algorithms/coprime_numbers/coprime_numbers.go
@@ -4,23 +4,17 @@ import "fmt"
 
 func gcd(a, b int) int {
 	for b != 0 {
-		tmp := a % b
-		a = b
-		b = tmp
+		a, b = b, a%b
 	}
 	return a
 }
 
 func coprime(a, b int) bool {
-	if a > b {
-		return gcd(a, b) == 1
-	} else {
-		return gcd(b, a) == 1
-	}
+	return gcd(a, b) == 1
 }
 
 func main() {
-	a := 15
-	b := 14
+	a := 14
+	b := 15
 	fmt.Printf("Are %v and %v coprime? %v\n", a, b, coprime(a, b))
 }


### PR DESCRIPTION
- use tuple assignment instead of temp variable
- remove unnecessary check when calling gcd, as the function works
  correctly independently of which argument is larger
