### PR TITLE
Renames elixir stack method and parameters

### DIFF
--- a/code/data_structures/stack/stack/stack.ex
+++ b/code/data_structures/stack/stack/stack.ex
@@ -3,16 +3,15 @@
 # Pattern matching
 # new_element = head
 # items = tail
-
 defmodule Stack do
   def new, do: [] 
   
   def push(new_element, items), do: [new_element | items]
   
-  def pop([new_element | items]), do: {new_element, items}
+  def pop([element | items]), do: {element, items}
   
   def empty?([]), do: true
   def empty?(_), do: false
   
-  def top([head | _]), do: head
+  def peek([head | _]), do: head
 end


### PR DESCRIPTION
**Fixes issue:**
No specific issue.

**Changes:**
Just changed the name of the method `top` to `peek` to be more consistent with the other stacks.