### PR TITLE
Fix Morse Code for the number 9

### DIFF
--- a/code/cryptography/morse_cipher/morse_code_generator.cpp
+++ b/code/cryptography/morse_cipher/morse_code_generator.cpp
@@ -17,7 +17,7 @@ encrypt['U']="..-";encrypt['V']="...-"; encrypt['W']=".--"; encrypt['X']="-..-";
 encrypt['Y']="-.--";encrypt['Z']="--..";
 encrypt['1']=".----"; encrypt['2']="..---"; encrypt['3']="...--";encrypt['4']="....-";
 encrypt['5']="....."; encrypt['6']="-...."; encrypt['7']="--...";
-encrypt['8']="---.."; encrypt['9']="---."; encrypt['0']="-----"; 
+encrypt['8']="---.."; encrypt['9']="----."; encrypt['0']="-----"; 
 
 string cipher;
 for(int i=0;i<msg.size();i++)


### PR DESCRIPTION
**Fixes issue:** Incorrect output after encrypting '9'.

**Changes:**
Changed the value for the key '9' from "---." to "----."
