### PR TITLE
fix bug in comb sort C++

### DIFF
--- a/code/sorting/comb_sort/comb_sort.cpp
+++ b/code/sorting/comb_sort/comb_sort.cpp
@@ -5,7 +5,7 @@ using namespace std;
 int updateGap(int gap){
     gap = (gap*10)/13;
     if(gap < 1)
-        return gap;
+        return 1;
     else
         return gap;
 }


### PR DESCRIPTION
fixes an out-of-bounds error when gap=0
