### PR TITLE
Match Java classes to their filenames.

### DIFF
--- a/code/mathematical-algorithms/2Sum/2sum.java
+++ b/code/mathematical-algorithms/2Sum/2sum.java
@@ -1,6 +1,6 @@
 // Part of Cosmos by OpenGenus Foundation
 
-public class two_sum {
+public class 2sum {
     private static int[] two_sum(int[] arr, int target) {
         if (arr == null || arr.length < 2) return new int[]{0, 0};
 

--- a/code/string-algorithms/aho_corasick_algorithm/aho_corasick.java
+++ b/code/string-algorithms/aho_corasick_algorithm/aho_corasick.java
@@ -1,6 +1,6 @@
 import java.util.*;
 
-public class AhoCorasick {
+public class aho_corasick{
 
 	static final int ALPHABET_SIZE = 26;
 

--- a/code/string-algorithms/password_strength_checker/pw_checker.java
+++ b/code/string-algorithms/password_strength_checker/pw_checker.java
@@ -1,4 +1,4 @@
-public class Password {
+public class pw_checker{
 
 	public static void main(String[] args) {	
 		// password to check


### PR DESCRIPTION
Java class name must match filename

**Fix for issue:** #2143 
