### PR TITLE
Removed platform specific libraries.

### DIFF
--- a/code/data_structures/linked_list/circular_linked_list/circular_linked_list.cpp
+++ b/code/data_structures/linked_list/circular_linked_list/circular_linked_list.cpp
@@ -1,5 +1,4 @@
 #include <iostream>
-#include <conio.h>
 // Part of Cosmos by OpenGenus Foundation
 using namespace std;
 
@@ -52,6 +51,5 @@ while(c<3 && c>0){
 
 }
 
-getch();
 return 0;
 }


### PR DESCRIPTION
**Fixes issue:** #2150

**Changes:**
Removed conio.h and dependent function ( 'getch' ) as it is platform specific ( 'Windows' ) and hence restricts usage on other platforms.
