### PR TITLE
Added Javadoc commenting under the coding style comment section.

### DIFF
--- a/guides/coding_style/java/style.md
+++ b/guides/coding_style/java/style.md
@@ -55,13 +55,13 @@ Comments should have a space following the double slashes. Any multiline comment
 
  /**
   *
- * This is a Javadoc comment that
- * is describing a method in a class
- * that will modify a string
- * @author myName
- * @param word the string to be manipulated
- * @return the modified string
- *
+  * This is a Javadoc comment that
+  * is describing a method in a class
+  * that will modify a string
+  * @author myName
+  * @param word the string to be manipulated
+  * @return the modified string
+  *
   */
 ```
 

--- a/guides/coding_style/java/style.md
+++ b/guides/coding_style/java/style.md
@@ -58,7 +58,7 @@ Comments should have a space following the double slashes. Any multiline comment
   * This is a Javadoc comment that
   * is describing a method in a class
   * that will modify a string
-	*
+  *
   * @author myName
   * @param word the string to be manipulated
   * @return the modified string

--- a/guides/coding_style/java/style.md
+++ b/guides/coding_style/java/style.md
@@ -55,13 +55,13 @@ Comments should have a space following the double slashes. Any multiline comment
 
  /**
   *
-	* This is a Javadoc comment that
-	* is describing a method in a class
-	* that will modify a string
-	* @author myName
-	* @param word the string to be manipulated
-	* @return the modified string
-	*
+* This is a Javadoc comment that
+* is describing a method in a class
+* that will modify a string
+* @author myName
+* @param word the string to be manipulated
+* @return the modified string
+*
   **/
 ```
 

--- a/guides/coding_style/java/style.md
+++ b/guides/coding_style/java/style.md
@@ -37,7 +37,7 @@ int[] arr = new int[] { 1, 2, 3 };
 
 Comments
 ---
-Comments should have a space following the double slashes. Any multiline comments should be created with the /\*\*/ delimiters. A special type of comment, called Javadoc commenting, should be implemented using the /\*\*\*\*/ delimiters. Javadoc comments are used with tags like @author, @param, and @return to document the purpose of methods and classes in code.
+Comments should have a space following the double slashes. Any multiline comments should be created with the /\*\*/ delimiters. A special type of comment, called Javadoc commenting, should be implemented using the /\*\* \*/ delimiters. Javadoc comments are used with tags like @author, @param, and @return to document the purpose of methods and classes in code.
 
 ```Java
 // Single line comment, with space after slashes
@@ -55,14 +55,14 @@ Comments should have a space following the double slashes. Any multiline comment
 
  /**
   *
-* This is a Javadoc comment that
-* is describing a method in a class
-* that will modify a string
-* @author myName
-* @param word the string to be manipulated
-* @return the modified string
-*
-  **/
+ * This is a Javadoc comment that
+ * is describing a method in a class
+ * that will modify a string
+ * @author myName
+ * @param word the string to be manipulated
+ * @return the modified string
+ *
+  */
 ```
 
 Control flow statements

--- a/guides/coding_style/java/style.md
+++ b/guides/coding_style/java/style.md
@@ -6,7 +6,7 @@ All braces should start on the same line as the method they are delimiting. If a
 
 ```Java
 if (true) {
-	/* 
+	/*
 	** Multiple lines
 	** of code
 	*/
@@ -18,7 +18,7 @@ while (true)
 if (true || false) {
 	// One line of code
 } else {
-	/* 
+	/*
 	** More than one line of code,
 	** so all blocks should be delimited.
 	*/
@@ -37,7 +37,7 @@ int[] arr = new int[] { 1, 2, 3 };
 
 Comments
 ---
-Comments should have a space following the double slashes. Any multiline comments should be created with the /\*\*/ delimiters.
+Comments should have a space following the double slashes. Any multiline comments should be created with the /\*\*/ delimiters. A special type of comment, called Javadoc commenting, should be implemented using the /\*\*\*\*/ delimiters. Javadoc comments are used with tags like @author, @param, and @return to document the purpose of methods and classes in code.
 
 ```Java
 // Single line comment, with space after slashes
@@ -52,6 +52,17 @@ Comments should have a space following the double slashes. Any multiline comment
  * acceptable
  *
  */
+
+ /**
+  *
+	* This is a Javadoc comment that
+	* is describing a method in a class
+	* that will modify a string
+	* @author myName
+	* @param word the string to be manipulated
+	* @return the modified string
+	*
+  **/
 ```
 
 Control flow statements

--- a/guides/coding_style/java/style.md
+++ b/guides/coding_style/java/style.md
@@ -53,17 +53,17 @@ Comments should have a space following the double slashes. Any multiline comment
  *
  */
 
- /**
-  *
-  * This is a Javadoc comment that
-  * is describing a method in a class
-  * that will modify a string
-  *
-  * @author myName
-  * @param word the string to be manipulated
-  * @return the modified string
-  *
-  */
+/**
+ *
+ * This is a Javadoc comment that
+ * is describing a method in a class
+ * that will modify a string
+ *
+ * @author myName
+ * @param word the string to be manipulated
+ * @return the modified string
+ *
+ */
 ```
 
 Control flow statements

--- a/guides/coding_style/java/style.md
+++ b/guides/coding_style/java/style.md
@@ -58,6 +58,7 @@ Comments should have a space following the double slashes. Any multiline comment
   * This is a Javadoc comment that
   * is describing a method in a class
   * that will modify a string
+	*
   * @author myName
   * @param word the string to be manipulated
   * @return the modified string


### PR DESCRIPTION
**Fixes issue:** Issue #2033 Added Javadoc commenting under the coding style comment section.

**Changes:**
Added two sentences explaining how to use and implement Javadoc comments. Also added an example of a Javadoc comment for a String manipulation method.
