### PR TITLE
improved performance of Bitcount example in C/C++, also fixed comments

### DIFF
--- a/code/bit-manipulation/count_set_bits/count_set_bits.c
+++ b/code/bit-manipulation/count_set_bits/count_set_bits.c
@@ -3,8 +3,8 @@
 int count_set_bits(int n){
 	int c = 0;
 	while (n) {
-		c += (n & 1);
-		n >>= 1;
+		c++;
+		n&=(n-1);
 	}
 	return c;
 }

--- a/code/bit-manipulation/count_set_bits/count_set_bits.cpp
+++ b/code/bit-manipulation/count_set_bits/count_set_bits.cpp
@@ -4,8 +4,8 @@ using namespace std;
 int count(int n){
 	int c = 0;
 	while (n) {
-		c += (n & 1);
-		n >>= 1;
+		c++;
+		n&=(n-1);
 	}
 	return c;
 }
@@ -14,12 +14,12 @@ int main() {
 	
 	int n;
 	cin >> n;
-	// manual
-	cout<<count(n);
-	// builtin
-	// this is c++ builtin function very less people know about this.
-    	std :: cout << __builtin_popcount(5); //will return 2
-	// avalable in c, c++
+	
+    #ifdef BUILTIN
+    cout << __builtin_popcount(n); // use builtin popcount
+    #else
+	cout<<count(n);// manual
+    #endif
 	
 	return 0;
 }


### PR DESCRIPTION
**Fixes issue:**
C/C++ example for Bitcounting used a non optimal algorithm.
**Changes:**
 gcc will compile this algorithm to use the "blsr" instruction when avaliable meaning that 
n&=(n-1);
only uses one instruction.
Clang will even compile it to use the builtin popcnt instruction resulting in a single instruction for the whole algorithm
