### PR TITLE
C# guidelines markdown styling fixes

### DIFF
--- a/guides/coding_style/c#/README.md
+++ b/guides/coding_style/c#/README.md
@@ -1,5 +1,6 @@
-#Cosmos Guides
+#osmos Guides
 > Your personal library of every algorithm and data structure code that you will ever encounter.  
+
 Please follow the official Microsoft [C# coding guidelines](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/inside-a-program/coding-conventions).
 
 

--- a/guides/coding_style/c#/README.md
+++ b/guides/coding_style/c#/README.md
@@ -1,5 +1,5 @@
-# Cosmos Guides
-> Your personal library of every algorithm and data structure code that you will ever encounter
+#Cosmos Guides
+> Your personal library of every algorithm and data structure code that you will ever encounter.  
 Please follow the official Microsoft [C# coding guidelines](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/inside-a-program/coding-conventions).
 
 

--- a/guides/coding_style/c#/README.md
+++ b/guides/coding_style/c#/README.md
@@ -1,4 +1,4 @@
-#osmos Guides
+#Cosmos Guides
 > Your personal library of every algorithm and data structure code that you will ever encounter.  
 
 Please follow the official Microsoft [C# coding guidelines](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/inside-a-program/coding-conventions).


### PR DESCRIPTION
**Fixes issue:** 
Fixes some markdown styling in the C# guidelines

**Changes:**
Seprate text into paragraphs.
