### PR TITLE
Add rigorous checking for finding if a number is square or not

### DIFF
--- a/code/mathematical-algorithms/Check_is_square/FindingISquare.cpp
+++ b/code/mathematical-algorithms/Check_is_square/FindingISquare.cpp
@@ -3,15 +3,24 @@
 using namespace std;
 
 // Function to check squares
-int isSquare ( int n ){
+bool isSquare ( int n ){
 	
 	if ( n < 0 )
-		return 0;
+		return false;
 
 	//remove digits after decimal
 	int root = (int)round(sqrt(n)); 
 	
-	return ( root * root ) == n ;
+	bool is_square = false;
+	for(int i=root-2; i<root+2; i++)
+	{
+		if((i*i) == n)
+		{
+			is_square = true;
+			break;
+		}
+	}
+	return is_square;
 }
 
 


### PR DESCRIPTION
**Fixes issue:** Floating point calculation is not reliable in C++. Thus it is required to do rigorous checking. In many cases, sqrt(9) may return 2.9999999999 (This depends on compiler and computer). That's why you need to check using a range of numbers.

**Changes:**
* Make the C++ function for checking if a number is square more rigorous.