### PR TITLE
Switch Statements Java Coding Style Guide

### DIFF
--- a/guides/coding_style/java/style.md
+++ b/guides/coding_style/java/style.md
@@ -192,13 +192,13 @@ the variable being checked does not match up with any of the cases in the statem
  */
 switch (num) {
 	case 1:  // Do something
-                break;
+                 break;
 	case 2:  // Do something
-                break;
+                 break;
 	case 3:  // Do something
-                break;
+                 break;
 	default: // Do something
-                break;
+                 break;
 }
 ```
 Statements

--- a/guides/coding_style/java/style.md
+++ b/guides/coding_style/java/style.md
@@ -192,13 +192,13 @@ the variable being checked does not match up with any of the cases in the statem
  */
 switch (num) {
 	case 1:  // Do something
-           break;
+					 break;
 	case 2:  // Do something
-           break;
+					 break;
 	case 3:  // Do something
-           break;
+					 break;
 	default: // Do something
-           break;
+					 break;
 }
 ```
 Statements

--- a/guides/coding_style/java/style.md
+++ b/guides/coding_style/java/style.md
@@ -183,8 +183,24 @@ public void bar() {}
 
 Switch statements
 ---
-All switch cases should end with either a `break` or `return` keyword. Every switch statement should also contain a `default` case.
-
+All switch cases should end with either a `break` or `return` keyword. Every switch statement should also contain a `default` case for when
+the variable being checked does not match up with any of the cases in the statement.
+```Java
+/* Given a number, num, do something
+ * different depending on what num is
+ * (i.e. num is 1, 2, 3, or none)
+ */
+switch (num) {
+	case 1:  // Do something
+					 break;
+	case 2:  // Do something
+					 break;
+	case 3:  // Do something
+					 break;
+	default: // Do something
+					 break;
+}
+```
 Statements
 ---
 There should only be one statement per line. A statement is defined as ending in a semicolon, so this does not include control flow statements. The exceptions are a single statement that are delimited with braces, including anonymous methods and array instantiation.

--- a/guides/coding_style/java/style.md
+++ b/guides/coding_style/java/style.md
@@ -192,13 +192,13 @@ the variable being checked does not match up with any of the cases in the statem
  */
 switch (num) {
 	case 1:  // Do something
-					 break;
+               break;
 	case 2:  // Do something
-					 break;
+               break;
 	case 3:  // Do something
-					 break;
+               break;
 	default: // Do something
-					 break;
+               break;
 }
 ```
 Statements

--- a/guides/coding_style/java/style.md
+++ b/guides/coding_style/java/style.md
@@ -192,13 +192,13 @@ the variable being checked does not match up with any of the cases in the statem
  */
 switch (num) {
 	case 1:  // Do something
-               break;
+                   break;
 	case 2:  // Do something
-               break;
+                   break;
 	case 3:  // Do something
-               break;
+                   break;
 	default: // Do something
-               break;
+                   break;
 }
 ```
 Statements

--- a/guides/coding_style/java/style.md
+++ b/guides/coding_style/java/style.md
@@ -192,13 +192,13 @@ the variable being checked does not match up with any of the cases in the statem
  */
 switch (num) {
 	case 1:  // Do something
-                   break;
+                break;
 	case 2:  // Do something
-                   break;
+                break;
 	case 3:  // Do something
-                   break;
+                break;
 	default: // Do something
-                   break;
+                break;
 }
 ```
 Statements

--- a/guides/coding_style/java/style.md
+++ b/guides/coding_style/java/style.md
@@ -192,13 +192,13 @@ the variable being checked does not match up with any of the cases in the statem
  */
 switch (num) {
 	case 1:  // Do something
-					 break;
+           break;
 	case 2:  // Do something
-					 break;
+           break;
 	case 3:  // Do something
-					 break;
+           break;
 	default: // Do something
-					 break;
+           break;
 }
 ```
 Statements

--- a/guides/coding_style/python/style.md
+++ b/guides/coding_style/python/style.md
@@ -10,8 +10,8 @@ Use concise, pythonic, but **readable** code
 
 Variables
 ---
-When creating variables, use lowercase letters throughout the names. When you
-create a variable with more than one word in its name, use an underscore to
+When creating variables, use lowercase letters throughout the names. When
+creating a variable with more than one word in its name, use an underscore to
 separate the words. There is no need for type declaration in Python.
 
 **WRONG**

--- a/guides/coding_style/python/style.md
+++ b/guides/coding_style/python/style.md
@@ -6,8 +6,33 @@ One statement per line
 
 Use Python3! Check the [current time until deactivation of Python2 here](https://pythonclock.org/)
 
-Use consise, pythonic, but **readable** code
+Use concise, pythonic, but **readable** code
 
+Variables
+---
+When creating variables, use lowercase letters throughout the names. When you
+create a variable with more than one word in its name, use an underscore to
+separate the words. There is no need for type declaration in Python.
+
+**WRONG**
+```Python
+# variable declaration statement here more reminiscent of Java
+int i = 0
+```
+
+**RIGHT**
+```Python
+# variable declaration and initialization
+number = 25
+
+# variable assignment
+number = 0
+
+# variables with more than one word in their name
+anagram_count = 0
+amount_of_pies = 200
+our_keyword = 'HelloWorld'
+```
 
 Code Blocks
 ---
@@ -75,7 +100,7 @@ if b:
 
 Functions
 ---
-Function names should be lowercase, with words seperated by underscores as necessary
+Function names should be lowercase, with words separated by underscores as necessary
 
 **WRONG**
 ```Python
@@ -97,7 +122,7 @@ def right_func(*args):
 
 Classes
 ---
-- Class names shoud use upper camel case
+- Class names should use upper camel case
 - Always use *self* for the first argument to instance methods
 
 **WRONG**
@@ -116,7 +141,7 @@ class RightClassName(object):
 
 Constants
 ---
-Constant variable names should be all uppercase, with words sperated by underscores
+Constant variable names should be all uppercase, with words separated by underscores
 
 **WRONG**
 ```Python
@@ -127,6 +152,3 @@ max_length, total
 ```Python
 MAX_LENGTH, TOTAL
 ```
-
-
-


### PR DESCRIPTION
**Fixes issue:** #2033 

**Changes:**
Added some example code for switch statements. Also made the explanation of the default case a little more descriptive. Finally, added a variable naming convention section in the python style guide and fixed some spelling errors in that guide.
