### PR TITLE
General steps for principal component analysis added to README.md

### DIFF
--- a/code/artificial_intelligence/principal_component_analysis/README.md
+++ b/code/artificial_intelligence/principal_component_analysis/README.md
@@ -2,7 +2,7 @@
 > Your personal library of every algorithm and data structure code that you will ever encounter
 
 # Principal component analysis
-Solution to Principal Component Analysis Inspired by (Sebastian Raschka)[http://sebastianraschka.com/Articles/2014_pca_step_by_step.html]
+Solution to Principal Component Analysis Inspired by [Sebastian Raschka](http://sebastianraschka.com/Articles/2014_pca_step_by_step.html)
 
 The PCA approach may be summarized according to these steps:
 1. Take the whole dataset consisting of dd-dimensional samples ignoring the class labels

--- a/code/artificial_intelligence/principal_component_analysis/README.md
+++ b/code/artificial_intelligence/principal_component_analysis/README.md
@@ -2,11 +2,19 @@
 > Your personal library of every algorithm and data structure code that you will ever encounter
 
 # Principal component analysis
+Solution to Principal Component Analysis Inspired by (Sebastian Raschka)[http://sebastianraschka.com/Articles/2014_pca_step_by_step.html]
 
+The PCA approach may be summarized according to these steps:
+1. Take the whole dataset consisting of dd-dimensional samples ignoring the class labels
+2. Compute the dd-dimensional mean vector (i.e., the means for every dimension of the whole dataset)
+3. Compute the scatter matrix (alternatively, the covariance matrix) of the whole data set
+4. Compute eigenvectors and corresponding eigenvalues
+5. Sort the eigenvectors by decreasing eigenvalues and choose eigenvectors with the largest eigenvalues.
+6. Use eigenvector matrix to transform the samples onto the new subspace.
 ---
 
 <p align="center">
-	A massive collaborative effort by <a href="https://github.com/OpenGenus/cosmos">OpenGenus Foundation</a> 
+	A massive collaborative effort by <a href="https://github.com/OpenGenus/cosmos">OpenGenus Foundation</a>
 </p>
 
 ---


### PR DESCRIPTION
**Fixes issue:**
Regards the issue: #2730
**Changes:**
The general steps for approaching a Principal Component Analysis were added to README.md.
The solution was inspired by [Sebastian Raschka](http://sebastianraschka.com/Articles/2014_pca_step_by_step.html) website.
