### PR TITLE
Added Python Installation Guide for Mac

### DIFF
--- a/guides/installation_guides/python/mac/README.md
+++ b/guides/installation_guides/python/mac/README.md
@@ -1,6 +1,6 @@
 # Python Installation Guide
 
-*How to isntall Python on your machine*
+*How to install Python on your machine*
 
 As with most Linux distributions, Python comes installed by default. Despite that, the installed version could be different with the one that you need or some packages may not be installed.
 

--- a/guides/installation_guides/python/mac/README.md
+++ b/guides/installation_guides/python/mac/README.md
@@ -1,11 +1,29 @@
-# Cosmos Guides
-> Your personal library of every algorithm and data structure code that you will ever encounter
+# Python Installation Guide
 
+*How to isntall Python on your machine*
+
+As with most Linux distributions, Python comes installed by default. Despite that, the installed version could be different with the one that you need or some packages may not be installed.
+
+### Installing Python and the basic packages
+
+From Python's organization webpage (<a href="https://www.python.org/downloads/">python.org</a>) you can download the latest `.pkg` file. After that, just open the file and follow the instructions. This will also install the basic packages.
+
+You can download it from <a href="https://www.python.org/downloads/">here</a>.
+
+### Installing additional packages
+
+The easiest way to install a package is using the `pip` option in Terminal. If you are using Python 2 >=2.7.9 or Python 3 >=3.4 and installed it from the <a href="https://www.python.org/downloads/">python.org</a> webpage, you already have it installed.
+
+To install a package just open Terminal and type:
+
+`pip install packageName`
+
+Where `packageName` is the name of the package that you want to install. You can see the full list of available packages from <a href="https://pypi.python.org/pypi?%3Aaction=browse">here</a>.
 
 ---
 
 <p align="center">
-	A massive collaborative effort by <a href="https://github.com/OpenGenus/cosmos">OpenGenus Foundation</a> 
+	A massive collaborative effort by <a href="https://github.com/OpenGenus/cosmos">OpenGenus Foundation</a>
 </p>
 
 ---


### PR DESCRIPTION
+ Added the Python installation Guide for Mac. It also explains how to install a Python package using pip.

**Fixes issue:** 
#Adds the missing information for installing Python and it's packages in Mac. 

**Changes:**
Changes the README.md file from the installation guide of Python for Mac. 
