### PR TITLE
Add travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,61 @@
+matrix:
+  include:
+    #C with clang
+    - os: linux
+      language: c
+      script:
+        make c
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-trusty-5.0
+          packages:
+            - clang-5.0
+      env:
+        - MATRIX_EVAL="CC=clang-5.0"
+    
+    #C with gcc
+    - os: linux
+      language: c
+      script:
+        make c
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-7
+      env:
+        - MATRIX_EVAL="CC=gcc-7"
+        
+    #C++ with gcc
+    - os: linux
+      language: cpp
+      script:
+        make cpp
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
+      env:
+        - MATRIX_EVAL="CXX=g++-7"
+        
+    #C++ with clang
+    - os: linux
+      language: cpp
+      script:
+        make cpp
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-trusty-5.0
+          packages:
+            - clang-5.0
+      env:
+        - MATRIX_EVAL="CXX=clang++-5.0"
+        
+before_install:
+    - eval "${MATRIX_EVAL}"
+ 

--- a/makefile
+++ b/makefile
@@ -1,0 +1,14 @@
+#for C
+CFLAGS = -Wall -Wextra
+C_SOURCES := $(shell find -name '*.c')
+
+c: $(C_SOURCES)
+	$(CC) -o $@ $^ $(CFLAGS) 
+
+
+#for cpp
+CXXFLAGS = -Wall -Wextra
+CPP_SOURCES := $(shell find -name '*.cpp')
+
+cpp: $(CPP_SOURCES)
+	$(CXX) -o $@ $^ $(CXXFLAGS)  


### PR DESCRIPTION
Adds Travis support for C and C++, using gcc and clang compiler.
`-Wall` and `-Wextra` flags are enabled. 

For adding support for other languages, add the relevant section in the makefile and another section in Travis matrix.