### PR TITLE
Link math library while compiling C programs

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 #for C
-CFLAGS = -Wall -Wextra
+CFLAGS = -Wall -Wextra -lm
 C_SOURCES := $(shell find -name '*.c')
 
 c: $(C_SOURCES)


### PR DESCRIPTION
**Fixes issue:**
<!-- [Mention the issue number it fixes or add the details of the changes if it doesn't has a specific issue. -->
Added the -lm option, so that C programs which use math library compile properly. If any other libraries are needed, do add them.

**Changes:**
<!-- Add here what changes were made in this pull request. -->
 - Added `-lm` flag.
<!-- Make sure to look at the Style Guide for your language in guides/coding_style/language_name 
     Note: A coding style guide may not exist for your language, since this is still in beta.
-->
