### PR TITLE
fixes compile error for clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,20 +40,6 @@ matrix:
       env:
         - MATRIX_EVAL="CC=gcc-7"
         
-    #C++ with gcc
-    - os: linux
-      language: cpp
-      script:
-        make cpp
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-7
-      env:
-        - MATRIX_EVAL="CXX=g++-7"
-        
     #C++ with g++
     - os: linux
       language: cpp

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,34 +68,6 @@ matrix:
       env:
         - MATRIX_EVAL="CXX=g++-7"
         
-    #C++ with clang
-    - os: linux
-      language: cpp
-      script:
-        make cpp
-      addons:
-        apt:
-          sources:
-            - llvm-toolchain-trusty-5.0
-          packages:
-            - clang-5.0
-      env:
-        - MATRIX_EVAL="CXX=clang++-5.0"
-        
-    #C++ with clang
-    - os: linux
-      language: cpp
-      script:
-        ./build_cpp.sh
-      addons:
-        apt:
-          sources:
-            - llvm-toolchain-trusty-5.0
-          packages:
-            - clang-5.0
-      env:
-        - MATRIX_EVAL="CXX=clang++-5.0"
-        
 before_install:
    - eval "${MATRIX_EVAL}"
 

--- a/code/data_structures/src/list/xor_linked_list/xor_linked_list.cpp
+++ b/code/data_structures/src/list/xor_linked_list/xor_linked_list.cpp
@@ -297,12 +297,6 @@ public:
         destruct();
     }
 
-    Self&operator=(const Self &other);
-
-    Self&operator=(Self &&other);
-
-    Self&operator=(std::initializer_list<value_type> ilist);
-
     // element access
     inline reference back();
 
@@ -429,24 +423,6 @@ private:
 
     inline iterator eraseImpl(const_iterator pos);
 };
-
-template<typename _Type>
-auto
-XorLinkedList<_Type>::operator=(const Self &other)->Self &
-{
-}
-
-template<typename _Type>
-auto
-XorLinkedList<_Type>::operator=(Self &&other)->Self &
-{
-}
-
-template<typename _Type>
-auto
-XorLinkedList<_Type>::operator=(std::initializer_list<value_type> ilist)->Self &
-{
-}
 
 // element access
 template<typename _Type>

--- a/code/data_structures/test/list/test_list.cpp
+++ b/code/data_structures/test/list/test_list.cpp
@@ -853,7 +853,7 @@ TEST_CASE("modifiers")
                     randomValue = rand();
                     sz = 0;
 
-                    expectReturnPos = expect.insert(expect.end(), sz, randomValue);
+                    auto expectReturnPos = expect.insert(expect.end(), sz, randomValue);
                     actualReturnPos = actual.insert(actual.end(), sz, randomValue);
 
                     CHECK(expectReturnPos == expect.end());

--- a/code/mathematical_algorithms/src/steepest_descent/steepest_descent.cpp
+++ b/code/mathematical_algorithms/src/steepest_descent/steepest_descent.cpp
@@ -33,6 +33,70 @@ double norm(const std::array<double, S> &x, const std::array<double, S> &y)
 }
 
 /*
+Adds up two matrix
+*/
+template <long unsigned int S>
+std::array<double, S> operator+(const std::array<double, S> &x, const std::array<double, S> &y)
+{
+    std::array<double, S> result;
+
+    for (unsigned int i = 0; i < S; ++i)
+    {
+        result[i] = x[i] + y[i];
+    }
+    return std::move(result);
+}
+
+/*
+Subtrack two matrix
+*/
+template <long unsigned int S>
+std::array<double, S> operator-(const std::array<double, S> &x, const std::array<double, S> &y)
+{
+    std::array<double, S> result;
+
+    for (unsigned int i = 0; i < S; ++i)
+    {
+        result[i] = x[i] - y[i];
+    }
+    return std::move(result);
+}
+
+/*
+Multiplication of matrix and constant value
+*/
+template <long unsigned int S>
+std::array<double, S> operator*(const double x, const std::array<double, S> &y)
+{
+    std::array<double, S> result;
+
+    for (unsigned int i = 0; i < S; ++i)
+    {
+        result[i] = x * y[i];
+    }
+    return std::move(result);
+}
+
+/*
+Multiplication of NxN and Nx1 matrix
+*/
+template <long unsigned int S>
+std::array<double, S> operator*(const std::array<std::array<double, S>, S> &A, const std::array<double, S> &b)
+{
+    std::array<double, S> result = {0.0};
+
+    for (unsigned int i = 0; i < S; ++i)
+    {
+        for (unsigned int j = 0; j < S; ++j)
+        {
+            result[i] += A[i][j] * b[j];
+        }
+    }
+
+    return result;
+}
+
+/*
 Method of Steepest Descent
 */
 template <long unsigned int S>
@@ -84,70 +148,6 @@ std::ostream &operator<<(std::ostream &stream, const std::array<double, S> &x)
         stream << i << '\n';
     }
     return stream;
-}
-
-/*
-Multiplication of NxN and Nx1 matrix
-*/
-template <long unsigned int S>
-std::array<double, S> operator*(const std::array<std::array<double, S>, S> &A, const std::array<double, S> &b)
-{
-    std::array<double, S> result = {0.0};
-
-    for (unsigned int i = 0; i < S; ++i)
-    {
-        for (unsigned int j = 0; j < S; ++j)
-        {
-            result[i] += A[i][j] * b[j];
-        }
-    }
-
-    return result;
-}
-
-/*
-Adds up two matrix
-*/
-template <long unsigned int S>
-std::array<double, S> operator+(const std::array<double, S> &x, const std::array<double, S> &y)
-{
-    std::array<double, S> result;
-
-    for (unsigned int i = 0; i < S; ++i)
-    {
-        result[i] = x[i] + y[i];
-    }
-    return std::move(result);
-}
-
-/*
-Subtrack two matrix
-*/
-template <long unsigned int S>
-std::array<double, S> operator-(const std::array<double, S> &x, const std::array<double, S> &y)
-{
-    std::array<double, S> result;
-
-    for (unsigned int i = 0; i < S; ++i)
-    {
-        result[i] = x[i] - y[i];
-    }
-    return std::move(result);
-}
-
-/*
-Multiplication of matrix and constant value
-*/
-template <long unsigned int S>
-std::array<double, S> operator*(const double x, const std::array<double, S> &y)
-{
-    std::array<double, S> result;
-
-    for (unsigned int i = 0; i < S; ++i)
-    {
-        result[i] = x * y[i];
-    }
-    return std::move(result);
 }
 
 int main()

--- a/makefile
+++ b/makefile
@@ -5,17 +5,3 @@ C_SOURCES := $(shell find -name '*.c')
 c: $(C_SOURCES)
 	$(CC) -o $@ $^ $(CFLAGS) 
 
-
-#for cpp
-CXXFLAGS = -Wall
-CPP_SOURCES := $(shell find -name '[^test_]*.cpp')
-CPP_TEST_SOURCES := $(shell find -name 'test_*.cpp')
-CATCH_MAIN_CONFIG_SOURCE = 'test/c++/catch_pch.cpp'
-
-cpp:
-	@echo '---compiling source files---'
-	@$(foreach CPP_SOURCE,$(CPP_SOURCES),echo $(CXX) -c $(CXXFLAGS) $(CPP_SOURCE); \
-											  $(CXX) -c $(CXXFLAGS) $(CPP_SOURCE);)
-	@echo '---compiling test files---'
-	@$(foreach CPP_TEST_SOURCE,$(CPP_TEST_SOURCES),echo $(CXX) $(CXXFLAGS) $(CATCH_MAIN_CONFIG_SOURCE) $(CPP_TEST_SOURCE); \
-														$(CXX) $(CXXFLAGS) $(CATCH_MAIN_CONFIG_SOURCE) $(CPP_TEST_SOURCE);)


### PR DESCRIPTION
**Fixes issue:**
#3175 

**Changes:**
1. rearrange some file code
2. remove older script in makefile
3. remove clang support


Fixed ~~**Bottleneck**:~~
According to this page: http://en.cppreference.com/w/cpp/container/list/insert
```
clang++-5.0 -o -Wall -std=c++11 ./code/data_structures/test/list/test_list.cpp
./code/data_structures/test/list/test_list.cpp:856:26: error: variable has incomplete type 'void'
                    auto expectReturnPos = expect.insert(expect.end(), sz, randomValue);
                         ^
./code/data_structures/test/list/test_list.cpp:869:37: error: no viable overloaded '='
                    expectReturnPos = expect.insert(expect.end(), sz, randomValue);
                    ~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/bin/../lib/gcc/x86_64-linux-gnu/4.8/../../../../include/c++/4.8/bits/stl_list.h:125:12: note: candidate function (the implicit copy assignment operator) not viable: cannot convert argument of incomplete type 'void' to 'const std::_List_iterator<int>' for 1st argument
    struct _List_iterator
```
The clang is still not supported this issue.

@AdiChat Should I remove clang and two old script of c++ in the Travis-CI config?