### PR TITLE
add implementations to validate ipv4 and ipv6 in C

### DIFF
--- a/validate_ipv4.c
+++ b/validate_ipv4.c
@@ -1,0 +1,62 @@
+/* This implementation reads in a file as argv[1] and checks if each line of the file is a valid IPv4 address.
+Algorithm of the IPv4 validation is in the char *is_ipv4(char *ip_addr) function.
+
+Implementation utilized inet_pton() and information about that function 
+from https://beej.us/guide/bgnet/html/multi/inet_ntopman.html */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <arpa/inet.h>
+
+char 
+*is_ipv4(char *ip_addr);
+
+char 
+*is_ipv4(char *ip_addr) 
+{
+	char *ans = "";
+	struct sockaddr_in sa;
+	
+	if(inet_pton(AF_INET, ip_addr, &(sa.sin_addr))) {
+		ans = "yes";
+	} else {
+		ans = "no";
+	}
+
+	return ans;
+}
+
+int 
+main(int argc, char *argv[]) 
+{
+	ssize_t n;
+	char *line = NULL;
+	char *ip_addr;
+	size_t size = 32;
+	FILE *fp;
+
+	const char *filename = argv[1];
+	fp = fopen(filename, "r");
+
+	if (!fp) {
+		fprintf(stderr, "Error in opening the file!\n");
+		exit(1);
+	}
+
+	while ((n = getline(&line, &size, fp)) != -1) {
+		if(line[n-1] == '\n') {
+			line[n-1] = '\0';
+			ip_addr = (char *) malloc(n-2);
+			strncpy(ip_addr, line, n-2);
+		} else {
+			ip_addr = (char *) malloc(n);
+			strncpy(ip_addr, line, n);
+		}
+		char* ans = is_ipv4(ip_addr);
+		printf("Is '%s' valid IPv4? \n%s\n", ip_addr, ans);
+	}
+
+	fclose(fp);
+	return 0;
+}

--- a/validate_ipv6.c
+++ b/validate_ipv6.c
@@ -1,0 +1,62 @@
+/* This implementation reads in a file as argv[1] and checks if each line of the file is a valid IPv6 address.
+Algorithm of the IPv6 validation is in the char *is_ipv6(char *ip_addr) function.
+
+Implementation utilized inet_pton() and information about that function 
+from https://beej.us/guide/bgnet/html/multi/inet_ntopman.html */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <arpa/inet.h>
+
+char 
+*is_ipv6(char *ip_addr);
+
+char 
+*is_ipv6(char *ip_addr) 
+{
+	char *ans = "";
+	struct sockaddr_in6 sa_6;
+
+	if(inet_pton(AF_INET6, ip_addr, &(sa_6.sin6_addr))) {
+		ans = "yes";
+	} else {
+		ans = "no";
+	}
+
+	return ans;
+}
+
+int 
+main(int argc, char *argv[]) 
+{
+	ssize_t n;
+	char *line = NULL;
+	char *ip_addr;
+	size_t size = 32;
+	FILE *fp;
+
+	const char *filename = argv[1];
+	fp = fopen(filename, "r");
+
+	if (!fp) {
+		fprintf(stderr, "Error in opening the file!\n");
+		exit(1);
+	}
+
+	while ((n = getline(&line, &size, fp)) != -1) {
+		if(line[n-1] == '\n') {
+			line[n-1] = '\0';
+			ip_addr = (char *) malloc(n-2);
+			strncpy(ip_addr, line, n-2);
+		} else {
+			ip_addr = (char *) malloc(n);
+			strncpy(ip_addr, line, n);
+		}
+		char* ans = is_ipv6(ip_addr);
+		printf("Is '%s' valid IPv6? \n%s\n", ip_addr, ans);
+	}
+
+	fclose(fp);
+	return 0;
+}


### PR DESCRIPTION


**Fixes issue:**
#3431 
Added validate IPv6 and IPv4 (2 separate but really similar files) in C


**Changes:**
Implemented two separate but similar files called validate_ipv4.c and validate_ipv6 that validate both types respectively. They both, however, have very similar code with very small minor differences and I can try to do one of them in a completely different way if needed.


<!-- Make sure to look at the Style Guide for your language in guides/coding_style/language_name:

     https://github.com/OpenGenus/cosmos/tree/master/guides/coding_style

     Note: A coding style guide may not exist for your language, since this is still in beta.
-->

<!-- Make sure to look at the Documentation Style Guide in guides/documentation.md:

     https://github.com/OpenGenus/cosmos/blob/master/guides/documentation_guide.md

     The document style guide may not apply for your algorithm category, you must also look at specified guide under all of the directory in the category, e.g., for project euler:

     https://github.com/OpenGenus/cosmos/blob/master/code/online_challenges/src/project_euler/documentation_guide.md
-->
