### PR TITLE
[JS] Use .reduce to get the sum in 'average'

### DIFF
--- a/code/unclassified/src/average/average.js
+++ b/code/unclassified/src/average/average.js
@@ -1,14 +1,15 @@
 /* Part of Cosmos by OpenGenus Foundation */
 
 // finds the average of an array of numbers.
-//Using map function
+// Using reduce function
 function getAverage(numbers){
-    var sum = 0;
-    numbers.map(function(number){
-		sum += number;
-	})
+    var sum = numbers.reduce(function(sum, number) {
+        return sum += number;
+    }, 0);
+
     return (sum / numbers.length);
 }
 
 nums = [10,20,30,40,50];
+
 console.log(getAverage(nums));


### PR DESCRIPTION
**Fixes issue:**

Avoid using `.map` (creates a new unnecessary array) to sum numbers.

This change uses `.reduce` which is perfectly suited for the case.

**Changes:**

- Removes spurious `.map` (should have been a `.forEach`) and replace it with a more functional-ly `.reduce` to calculate the sum.
- Minor source formatting fixes. Mostly indentation white space.
