### PR TITLE
Update dijkstra.js

### DIFF
--- a/code/graph_algorithms/src/dijkstra_shortest_path/dijkstra.js
+++ b/code/graph_algorithms/src/dijkstra_shortest_path/dijkstra.js
@@ -6,9 +6,9 @@
  */
 
 class Graph {
-  constructor(noOfVertices) {
-    this.V = noOfVertices;
-    this.graph = Array(noOfVertices).fill(Array(noOfVertices).fill(0)); // Creates an nxn zero matrix
+  constructor(graph) {
+    this.V = graph.length;
+    this.graph = graph;
   }
 
   printSolution(dist) {
@@ -37,7 +37,7 @@ class Graph {
   // Funtion that implements Dijkstra's single source
   // shortest path algorithm for a graph represented
   // using adjacency matrix representation
-  dijkstra(src) {
+  dijkstra(src = 0) {
     let dist = Array(this.V).fill(Infinity);
     let shortestPathSet = Array(this.V).fill(false);
     dist[src] = 0;
@@ -71,9 +71,7 @@ class Graph {
   }
 }
 
-g = new Graph(9);
-
-g.graph = [
+g = new Graph([
   [0, 4, 0, 0, 0, 0, 0, 8, 0],
   [4, 0, 8, 0, 0, 0, 0, 11, 0],
   [0, 8, 0, 7, 0, 4, 0, 0, 2],
@@ -83,6 +81,6 @@ g.graph = [
   [0, 0, 0, 0, 0, 2, 0, 1, 6],
   [8, 11, 0, 0, 0, 0, 1, 0, 7],
   [0, 0, 2, 0, 0, 0, 6, 7, 0]
-];
+]);
 
-g.dijkstra(0);
+g.dijkstra();


### PR DESCRIPTION
`Array(noOfVertices).fill(Array(noOfVertices).fill(0))` does not create an nxn matrix of zeroes. It creates an array of n references to the same array of n zeroes (that is to say, only 2 arrays are ever being created, rather than n+1). I also put a default value on the `Graph#dijkstra` method so it can be invoked without an argument.

**Fixes issue:**
<!-- [Mention the issue number it fixes or add the details of the changes if it doesn't has a specific issue. -->


**Changes:**
<!-- Add here what changes were made in this pull request. -->


<!-- Make sure to look at the Style Guide for your language in guides/coding_style/language_name:

     https://github.com/OpenGenus/cosmos/tree/master/guides/coding_style

     Note: A coding style guide may not exist for your language, since this is still in beta.
-->

<!-- Make sure to look at the Documentation Style Guide in guides/documentation.md:

     https://github.com/OpenGenus/cosmos/blob/master/guides/documentation_guide.md

     The document style guide may not apply for your algorithm category, you must also look at specified guide under all of the directory in the category, e.g., for project euler:

     https://github.com/OpenGenus/cosmos/blob/master/code/online_challenges/src/project_euler/documentation_guide.md
-->
