### PR TITLE
chnages in the comments of quick_sort.c

### DIFF
--- a/code/sorting/src/quick_sort/quick_sort.c
+++ b/code/sorting/src/quick_sort/quick_sort.c
@@ -9,8 +9,8 @@ void swap(int *p, int *q)
 }
 
 
-//Last element is used a spivot
-//Places elements smaller than pivot to its left side
+//Last element is used as pivot
+//Places elements smaller than or equal to pivot to its left side
 //Places elements larger than pivot to its right side
 int partition(int a[], int low, int high)
 {


### PR DESCRIPTION
**Fixes issue:**
changes in the comments of quick_sort.c


**Changes:**
 **a spivot** changed to **as pivot**
**smaller than** modified to **smaller than or equal to**


<!-- Make sure to look at the Style Guide for your language in guides/coding_style/language_name:

     https://github.com/OpenGenus/cosmos/tree/master/guides/coding_style

     Note: A coding style guide may not exist for your language, since this is still in beta.
-->

<!-- Make sure to look at the Documentation Style Guide in guides/documentation.md:

     https://github.com/OpenGenus/cosmos/blob/master/guides/documentation_guide.md

     The document style guide may not apply for your algorithm category, you must also look at specified guide under all of the directory in the category, e.g., for project euler:

     https://github.com/OpenGenus/cosmos/blob/master/code/online_challenges/src/project_euler/documentation_guide.md
-->
