### PR TITLE
Use idiomatic Rust for Linear Search

### DIFF
--- a/code/search/src/linear_search/linear_search.rs
+++ b/code/search/src/linear_search/linear_search.rs
@@ -1,7 +1,7 @@
-fn search(vec: &[i32], n: i32) -> Option<i32> {
+fn search(vec: &[i32], n: i32) -> Option<usize> {
     for i in 0..vec.len() {
         if vec[i] == n {
-            return Some(i as i32); // Element found
+            return Some(i); // Element found
         }
     }
     None


### PR DESCRIPTION
**Fixes issue:** N/A


**Changes:**
- Use idiomatic Rust for `linear_search.rs`.