### PR TITLE
Fix wrong algorithm

### DIFF
--- a/code/sorting/src/bubble_sort/README.md
+++ b/code/sorting/src/bubble_sort/README.md
@@ -35,10 +35,12 @@ Now, the array is already sorted, but our algorithm does not know if it is compl
 ```
 begin BubbleSort(list)
 
-   for all elements of list
-      if list[i] > list[i+1]
-         swap(list[i], list[i+1])
-      end if
+   for unsorted_end in list[n...1]
+      for unsorted_beg of list[1...unsorted_end-1]
+         if list[unsorted_beg] > list[unsorted_beg+1]
+            swap(list[unsorted_beg], list[unsorted_beg+1])
+         end if
+      end for
    end for
    
    return list


### PR DESCRIPTION
**Fixes issue:**
<!-- [Mention the issue number it fixes or add the details of the changes if it doesn't has a specific issue. -->
[3844](https://github.com/OpenGenus/cosmos/issues/3844)

**Changes:**
<!-- Add here what changes were made in this pull request. -->
1. Fix that We've left out a loop of the old bubble sort algorithm.

<!-- Make sure to look at the Style Guide for your language in guides/coding_style/language_name:

     https://github.com/OpenGenus/cosmos/tree/master/guides/coding_style

     Note: A coding style guide may not exist for your language, since this is still in beta.
-->

<!-- Make sure to look at the Documentation Style Guide in guides/documentation.md:

     https://github.com/OpenGenus/cosmos/blob/master/guides/documentation_guide.md

     The document style guide may not apply for your algorithm category, you must also look at specified guide under all of the directory in the category, e.g., for project euler:

     https://github.com/OpenGenus/cosmos/blob/master/code/online_challenges/src/project_euler/documentation_guide.md
-->
