### PR TITLE
Ruby: Add code for average stream numbers

### DIFF
--- a/code/mathematical_algorithms/src/average_stream_numbers/average_stream_numbers.rb
+++ b/code/mathematical_algorithms/src/average_stream_numbers/average_stream_numbers.rb
@@ -1,0 +1,26 @@
+# Part of Cosmos by OpenGenus Foundation
+
+def average_stream_number(input_array)
+  avg = 0
+  resultant_array = []
+  input_array.each_with_index do |element, i|
+    avg = average(element, avg, (i + 1))
+    puts avg
+    resultant_array << avg
+  end
+  resultant_array
+end
+
+def average(new_element, prev_avg, index)
+  ((prev_avg * (index - 1) + new_element).to_f / index)
+end
+
+# Dynamic array input
+puts 'Enter the size of array'
+size_of_array = gets.chomp.to_i
+input_array = []
+size_of_array.times.each do
+  input_array << gets.chomp.to_i
+end
+
+average_stream_number(input_array)


### PR DESCRIPTION
**Fixes issue:**
This PR implements the average stream number algorithm in Ruby. The issue corresponding to this PR is: https://github.com/OpenGenus/cosmos/issues/3931


**Changes:**
File added: `cosmos/code/mathematical_algorithms/src/average_stream_numbers/average_stream_numbers.rb`

<!-- Make sure to look at the Style Guide for your language in guides/coding_style/language_name:

     https://github.com/OpenGenus/cosmos/tree/master/guides/coding_style

     Note: A coding style guide may not exist for your language, since this is still in beta.
-->

<!-- Make sure to look at the Documentation Style Guide in guides/documentation.md:

     https://github.com/OpenGenus/cosmos/blob/master/guides/documentation_guide.md

     The document style guide may not apply for your algorithm category, you must also look at specified guide under all of the directory in the category, e.g., for project euler:

     https://github.com/OpenGenus/cosmos/blob/master/code/online_challenges/src/project_euler/documentation_guide.md
-->
