### PR TITLE
Added deleteFront() and deleteEnd()

### DIFF
--- a/code/data_structures/src/linked_list/linked_list.cpp
+++ b/code/data_structures/src/linked_list/linked_list.cpp
@@ -206,6 +206,45 @@ void Linkedlist<T>::deletePos(int pos)
 }
 
 template <typename T>
+void Linkedlist<T>::deleteEnd()
+{
+    Node<T> *pNode1,*pNode2;
+
+    if (header == nullptr)
+        std::cerr << "linked list already empty!" << std::endl;
+    else
+    {
+        pNode1 = header;
+        pNode2=header; 
+        while(pNode->pNext!=nullptr) {
+           pNode2=pNode1;
+           pNode1=pNode1->pNext;
+        }
+        pNode2->pNext=nullptr;
+        delete pNode1;
+    }
+    return;
+}
+
+template <typename T>
+void Linkedlist<T>::deleteFront()
+{
+    Node<T> *pNode;
+
+    if (header == nullptr)
+        std::cerr << "linked list already empty!" << std::endl;
+    else
+    {
+        pNode = header;
+        header=pNode->pNext;
+        pNode->pNext=nullptr;
+        delete pNode;
+        length--;
+    }
+    return;
+}
+
+template <typename T>
 void Linkedlist<T>::modify(int pos, const T& date)
 {
     if (pos < 1 || pos > length)


### PR DESCRIPTION
Added these two functions to delete node from end and delete node from front

Fixes issue #3606 


**Changes:**
Added two functions to delete a node from front and end of the linked list


<!-- Make sure to look at the Style Guide for your language in guides/coding_style/language_name:

     https://github.com/OpenGenus/cosmos/tree/master/guides/coding_style

     Note: A coding style guide may not exist for your language, since this is still in beta.
-->

<!-- Make sure to look at the Documentation Style Guide in guides/documentation.md:

     https://github.com/OpenGenus/cosmos/blob/master/guides/documentation_guide.md

     The document style guide may not apply for your algorithm category, you must also look at specified guide under all of the directory in the category, e.g., for project euler:

     https://github.com/OpenGenus/cosmos/blob/master/code/online_challenges/src/project_euler/documentation_guide.md
-->
