### PR TITLE
fix #4033 : add flags for compiling pthread headers

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 #for C
-CFLAGS = -Wall -Wextra -lm -lgraph
+CFLAGS = -Wall -Wextra -lm -lgraph -lpthread
 C_SOURCES := $(shell find code -name '*.c')
 
 c: $(C_SOURCES)


### PR DESCRIPTION
**Fixes issue:**
fix issue #4033 


**Changes:**
added cflag for pthread header files in makefile.