### PR TITLE
Updated `Readme.md` sentence Grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Following is the high-level structure of cosmos:
 * [String algorithms](/code/string_algorithms)
 * [Unclassified](/code/unclassified) 👻
 
-Each type has several hundreds of problems with solutions in several languages spanning `C`, `C++`, `Java`, `Python`, `Go` and others.
+Each type has several hundred problems with solutions in languages spanning `C`, `C++`, `Java`, `Python`, `Go` and others.
 
 # Maintainers
 


### PR DESCRIPTION
Updated line `43`'s grammar in `Readme.md`

**Changes:**
- Updated "several hundreds" => "several hundred" (several implies plurality and does not need to repeat)
-  Updated "solutions in several languages spanning" => "solutions in languages spanning" (It will feel better because of the repetition several doesn't need to be repeated"



<!-- Make sure to look at the Style Guide for your language in guides/coding_style/language_name:

     https://github.com/OpenGenus/cosmos/tree/master/guides/coding_style

     Note: A coding style guide may not exist for your language, since this is still in beta.
-->

<!-- Make sure to look at the Documentation Style Guide in guides/documentation.md:

     https://github.com/OpenGenus/cosmos/blob/master/guides/documentation_guide.md

     The document style guide may not apply for your algorithm category, you must also look at specified guide under all of the directory in the category, e.g., for project euler:

     https://github.com/OpenGenus/cosmos/blob/master/code/online_challenges/src/project_euler/documentation_guide.md
-->
