### PR TITLE
Correct implementation of bogo sort in GO

### DIFF
--- a/code/sorting/src/bogo_sort/bogo_sort.go
+++ b/code/sorting/src/bogo_sort/bogo_sort.go
@@ -1,34 +1,32 @@
-//Part of Cosmos Project by OpenGenus Foundation
-//Bogo Sort implementation on golang
-//Written by Guilherme Lucas(guilhermeslucas)
 package main
 
 import (
-    "fmt"
-    "sort"
-    "math/rand"
+  "fmt"
+  "sort"
+  "math/rand"
+  "time"
 )
 
 func shuffle(arr []int) []int {
-	for i := range arr {
-		j := rand.Intn(i + 1)
-		arr[i], arr[j] = arr[j], arr[i]
-	}
-
-	return arr
+  for i := range arr {
+    j := rand.Intn(i + 1)
+    arr[i], arr[j] = arr[j], arr[i]
+  }
+  return arr
 }
 
 func bogoSort (array []int) []int {
-    for {
-        if sort.IntsAreSorted(array) {
-            return array
-        }
-        array = shuffle(array[:])
+  for {
+    if sort.IntsAreSorted(array) {
+      return array
     }
+  array = shuffle(array[:])
+  }
 }
 
 func main() {
-    var array = []int{1,5,8,2,6,9}
-    sorted := bogoSort(array)
-    fmt.Println("Sorted sequence is:", sorted)
+  rand.Seed(time.Now().UnixNano())
+  var array = []int{1,5,8,2,6,9}
+  sorted := bogoSort(array)
+  fmt.Println("Sorted sequence is:", sorted)
 }


### PR DESCRIPTION
The previous implementation used a non-random seed. Having 'j' always cycle through the same list of numbers.
Now it takes the current time as seed for its pseudo-random number generation.

**Fixes issue:**
<!-- [Mention the issue number it fixes or add the details of the changes if it doesn't has a specific issue. -->


**Changes:**
<!-- Add here what changes were made in this pull request. -->
Add timestamp to be used as number generation seed

<!-- Make sure to look at the Style Guide for your language in guides/coding_style/language_name:

     https://github.com/OpenGenus/cosmos/tree/master/guides/coding_style

     Note: A coding style guide may not exist for your language, since this is still in beta.
-->

<!-- Make sure to look at the Documentation Style Guide in guides/documentation.md:

     https://github.com/OpenGenus/cosmos/blob/master/guides/documentation_guide.md

     The document style guide may not apply for your algorithm category, you must also look at specified guide under all of the directory in the category, e.g., for project euler:

     https://github.com/OpenGenus/cosmos/blob/master/code/online_challenges/src/project_euler/documentation_guide.md
-->
