### PR TITLE
adds .gitattributes - vendor Jupyter notebooks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb linguist-documentation


### PR DESCRIPTION
**Fixes issue:** [#5049](https://github.com/OpenGenus/cosmos/issues/5049)

**Changes:** `.gitattributes` added to exclude Jupyter notebooks from language statistics

**Warning**: it seems that Linguist takes a while [before to update statistics](https://github.com/github/linguist#how-linguist-works-on-githubcom), see also [here](https://github.com/github/linguist/issues/197).

However, using `github-linguist` locally, it successfully ignores Jupyter notebooks:

```37.67%  C++
16.35%  Python
12.38%  Java
12.12%  C
3.71%   JavaScript
2.89%   C#
2.73%   Swift
2.43%   Go
1.23%   Rust
1.20%   Scala
1.14%   Ruby
1.07%   PHP
0.93%   Objective-C
0.86%   Haskell
0.60%   Kotlin
0.59%   Shell
0.49%   TypeScript
0.28%   HTML
0.25%   MATLAB
0.17%   Makefile
0.14%   Brainfuck
0.12%   Elixir
0.11%   Ada
0.06%   Processing
0.05%   Julia
0.05%   Clojure
0.05%   Standard ML
0.04%   F#
0.04%   Nim
0.04%   Lua
0.04%   Elm
0.03%   Perl
0.03%   Prolog
0.02%   Erlang
0.02%   Visual Basic .NET
0.02%   OCaml
0.02%   Racket
0.02%   Fortran
0.02%   PureScript
0.01%   Reason
0.00%   Crystal
```
