### PR TITLE
pr for making array elements equal

### DIFF
--- a/code/mathematical_algorithms/src/minimum_operations_elements_equal/EqualizeEveryone.java
+++ b/code/mathematical_algorithms/src/minimum_operations_elements_equal/EqualizeEveryone.java
@@ -1,0 +1,26 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+class EqualizeEveryone {
+    public static void main(String[] args) throws java.lang.Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int t = Integer.parseInt(br.readLine());
+        while (t-- > 0){
+            int n = Integer.parseInt(br.readLine());
+            int[] arr = new int[n];
+            String[] input = br.readLine().split(" ");
+            int min = Integer.MAX_VALUE;
+            for(int i=0; i<n; i++){
+                arr[i] = Integer.parseInt(input[i]);
+                min = Math.min(arr[i],min);
+            }
+            int minOperations = 0;
+            for(int i=0; i<n; i++){
+                minOperations += arr[i]-min;
+            }
+            System.out.println(minOperations);
+        }
+
+    }
+}

--- a/scripts/global_metadata.json
+++ b/scripts/global_metadata.json
@@ -3988,6 +3988,15 @@
         "sieve_of_eratosthenes.cpp"
       ],
       "updated": "18-05-2019 08:11:06"
+    },
+    "minimum_operations_elements_equal": {
+      "location": "code/mathematical_algorithms/src/minimum_operations_elements_equal/",
+      "opengenus_discuss": "",
+      "opengenus_iq": "https://iq.opengenus.org/make-elements-equal/",
+      "files": [
+        "EqualizeEveryone.java"
+      ],
+      "updated": "29-04-2020 19:25:00"
     }
   },
   "main": {


### PR DESCRIPTION
**Changes:**
Added code for the article published at iq.opengenus

**Location**
code/mathematical_algorithms/src/minimum_operations_elements_equal/

**ArticleLink**
https://iq.opengenus.org/make-elements-equal/

**Description**
To find the minimum number of operations to make all the array elements equal. The operation includes incrementing all but one element of the array by 1 that is incrementing N-1 elements out of N elements. The approach uses some trick to make it efficient as explained in the above article with the thought process.
