### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/code/cryptography/src/atbash_cipher/atbash_cipher.py
+++ b/code/cryptography/src/atbash_cipher/atbash_cipher.py
@@ -15,4 +15,4 @@ def cipher(plaintext):
 if __name__ == "__main__":
     import sys
 
-    print cipher(sys.argv[1])
+    print(cipher(sys.argv[1]))


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.

**Fixes issue:**
<!-- [Mention the issue number it fixes or add the details of the changes if it doesn't has a specific issue. -->


**Changes:**
<!-- Add here what changes were made in this pull request. -->
Use print() function in both Python 2 and Python 3

<!-- Make sure to look at the Style Guide for your language in guides/coding_style/language_name:

     https://github.com/OpenGenus/cosmos/tree/master/guides/coding_style

     Note: A coding style guide may not exist for your language, since this is still in beta.
-->

<!-- Make sure to look at the Documentation Style Guide in guides/documentation.md:

     https://github.com/OpenGenus/cosmos/blob/master/guides/documentation_guide.md

     The document style guide may not apply for your algorithm category, you must also look at specified guide under all of the directory in the category, e.g., for project euler:

     https://github.com/OpenGenus/cosmos/blob/master/code/online_challenges/src/project_euler/documentation_guide.md
-->
