### PR TITLE
update and repair configuration of uncrustify submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,6 @@
 [submodule "third_party/uncrustify"]
 	path = third_party/uncrustify
 	url = https://github.com/uncrustify/uncrustify.git
-	branch = uncrustify-0.66.1
 [submodule "third_party/namanager"]
 	path = third_party/namanager
 	url = https://github.com/iattempt/namanager.git


### PR DESCRIPTION
**Fixes issue:**
allows for submodule updates without errors and updates uncrustify

**Changes:**
repairs call to non-existent uncrustify-0.66.1 branch (it‘s a tag, which as of 2020, means Git still won’t allow it to be treated as a submodule branch)

this pull partially undoes https://github.com/OpenGenus/cosmos/commit/ba0aae718eed705c9fb4cfc0e6b3662709ef727f by @iendeavor