### PR TITLE
fix: edit remove function of singly linked list

### DIFF
--- a/code/data_structures/src/list/singly_linked_list/singly_linked_list.js
+++ b/code/data_structures/src/list/singly_linked_list/singly_linked_list.js
@@ -57,23 +57,30 @@ function LinkedList() {
   this.remove = function(element) {
     var currentNode = head;
     var previousNode;
-
+  
+    // Check if head exist
+    if(!currentNode) console.log("list does not exist.");
+    
     //Check if the head node is the element to remove
     if (currentNode.element === element) {
       head = currentNode.next;
+      length--;
     } else {
       //Check which node is the node to remove
-      while (currentNode.element !== element) {
+      while (currentNode.element !== element && currentNode.next) {
         previousNode = currentNode;
         currentNode = currentNode.next;
       }
-
-      //Removing the currentNode
+      if(currentNode.element === element) {
+      //Removing the currentNode if the data is found after search
       previousNode.next = currentNode.next;
+      length--;
+      }
+      else {
+      // if the node could not found, log it
+      console.log("element not found");
+      }
     }
-
-    //Decrementing the length
-    length--;
   };
 
   //Return if the list is empty


### PR DESCRIPTION
Add condition to check if the element does not exist in the linked list.

**Fixes issue:**

- If the user enters an element which does not exist in the linked list, it gives error as shown below:
```
/Users/test/other/interview/test.js:66
            while (currentNode.element !== element) {
                               ^

TypeError: Cannot read property 'element' of null
    at LinkedList.remove (/Users/damlakoksal/other/interview/test.js:66:32)
    at Object.<anonymous> (/Users/damlakoksal/other/interview/test.js:194:10)
    at Module._compile (node:internal/modules/cjs/loader:1095:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1124:10)
    at Module.load (node:internal/modules/cjs/loader:975:32)
    at Function.Module._load (node:internal/modules/cjs/loader:816:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:79:12)
    at node:internal/main/run_main_module:17:47
    ```

**Changes:**

- Add extra condition to check if the element is in the list or not.
