### PR TITLE
Fix critical time complexity issue of queue operation in python and javascript

### DIFF
--- a/code/data_structures/src/queue/queue/queue.js
+++ b/code/data_structures/src/queue/queue/queue.js
@@ -3,46 +3,67 @@
  *
  */
 
-function Queue() {
-  store = [];
+function Queue(size_max) {
+  data = new Array(size_max + 1);
+  max = (size_max + 1);
+  start = 0;
+  end = 0;
 
-  this.show = () => {
-    console.log(store);
-  };
+  this.empty = () => {
+    return start == end;
+  }
 
-  this.enqueue = element => {
-    store.push(element);
-  };
+  this.full = () => {
+    return start == (end + 1) % max;
+  }
+
+  this.enqueue = (x) => {
+    if (this.full()) {
+      console.log("Queue full");
+      return false;
+    }
+    data[end] = x;
+    end = (end + 1) % max;
+    return true;
+  }
 
   this.dequeue = () => {
-    return store.shift();
-  };
+    if (this.empty()) {
+      console.log("Queue empty");
+      return;
+    }
+    x =  data[start];
+    start = (start + 1) % max;
+    return x;
+  }
 
-  this.front = () => {
-    return store[0];
-  };
+  this.top = () => {
+    if (this.empty()) {
+      console.log("Queue empty");
+      return;
+    }
+    return data[start];
+  }
 
-  this.rear = () => {
-    return store[store.length - 1];
-  };
-
-  this.size = () => {
-    return store.length;
-  };
-
-  this.isEmpty = () => {
-    return store.length === 0;
-  };
+  this.display = () => {
+    cur =  start
+    while (cur !=  end) {
+      console.log(data[cur])
+      cur = (cur + 1) % max
+    }
+  }
 }
 
-let q = new Queue();
+let q = new Queue(3);
 q.enqueue("a");
 q.enqueue("b");
 q.enqueue("c");
-q.enqueue("d");
-q.show();
-console.log("Front Element: ", q.front());
-console.log("Rear Element: ", q.rear());
+q.enqueue("d"); // Queue full
+q.display(); // a, b, c
 q.dequeue();
-console.log("After Dequeue: ");
-q.show();
+q.display(); // b, c
+q.dequeue();
+q.dequeue();
+q.dequeue(); // Queue empty
+q.enqueue("z");
+q.display() // z

--- a/code/data_structures/src/queue/queue/queue.py
+++ b/code/data_structures/src/queue/queue/queue.py
@@ -1,44 +1,44 @@
 # Part of Cosmos by OpenGenus Foundation
-import array
-
-
 class Queue:
     def __init__(self, size_max):
-        self.max = size_max
-        self.size = 0
-        self.data = []
+        self.data = [None] * (size_max + 1)
+        self.max = (size_max + 1)
+        self.head = 0
+        self.tail = 0
 
     def empty(self):
-        return self.size == 0
+        return self.head == self.tail
 
     def full(self):
-        return self.size == self.max
+        return self.head == (self.tail + 1) % self.max
 
     def enqueue(self, x):
-        if self.size == self.max:
+        if self.full():
             print("Queue full")
             return False
-        self.data.insert(0, x)
-        self.size += 1
+        self.data[self.tail] = x
+        self.tail = (self.tail + 1) % self.max
         return True
 
     def dequeue(self):
-        if self.size == 0:
+        if self.empty():
+            print("Queue empty")
             return None
-        x = self.data.pop()
-        self.size -= 1
+        x = self.data[self.head]
+        self.head = (self.head + 1) % self.max
         return x
 
-    def display(self):
-        if self.size == 0:
-            print("Queue is empty")
-        else:
-            out = ""
-            for ele in self.data:
-                out = out + " " + str(ele)
-            print(out[::-1])
-        return
+    def top(self):
+        if self.empty():
+            print("Queue empty")
+            return None
+        return self.data[self.head]
 
+    def display(self):
+        cur = self.head
+        while cur != self.tail:
+            print(self.data[cur])
+            cur = (cur + 1) % self.max
 
 print("Enter the size of Queue")
 n = int(input())
@@ -47,10 +47,11 @@ while True:
     print("Press E to enqueue an element")
     print("Press D to dequeue an element")
     print("Press P to display all elements of the queue")
+    print("Press T to show top element of the queue")
     print("Press X to exit")
     opt = input().strip()
     if opt == "E":
-        if q.size == q.max:
+        if q.full():
             print("Queue is full")
             continue
         print("Enter the element")
@@ -65,5 +66,7 @@ while True:
             print("Element is", ele)
     if opt == "P":
         q.display()
+    if opt == "T":
+        print(q.top())
     if opt == "X":
         break


### PR DESCRIPTION
**Fixes issue:**
A standard Queue data structure should have O(1) time complexity for all basic operations.

Since the following two operations take O(N) time:
`self.data.insert(0, x)` in python
`store.shift();` in javascript

The time complexity of some `enqueue` and `dequeue` operation will become O(N) instead of O(1)

**Changes:**

Major:
1. Rewrite the python and javascript implementation of queue and fix the time complexity issue of `enqueue` and `dequeue` from O(N) to O(1).
2. This implementation need users to decide the queue size at initialization.

Minor:
1. Add `top` operation for getting the top element from queue.
2. remove unrelated dependencies (`array`) in python implementation.