### PR TITLE
Updated ip_components range to 256

### DIFF
--- a/code/networking/src/validate_ip/validate_ipv4.py
+++ b/code/networking/src/validate_ip/validate_ipv4.py
@@ -6,7 +6,7 @@ def validate_ipv4(ip_addr):
         return False
     else:
         for component in ip_components:
-            if int(component) not in range(0, 255):
+            if int(component) not in range(0, 256):
                 return False
         return True
 


### PR DESCRIPTION
A standard IPv4 address can range from 0 to 255 in its components. In the if statement in line 9 the range was set to 255, so it only checked from 0 - 254. I quickly changed that to 256 so it checks if the ip components range from 0 - 255, which is correct.

**Fixes issue:**
<!-- [Mention the issue number it fixes or add the details of the changes if it doesn't has a specific issue. -->


**Changes:**
<!-- Add here what changes were made in this pull request. -->


<!-- Make sure to look at the Style Guide for your language in guides/coding_style/language_name:

     https://github.com/OpenGenus/cosmos/tree/master/guides/coding_style

     Note: A coding style guide may not exist for your language, since this is still in beta.
-->

<!-- Make sure to look at the Documentation Style Guide in guides/documentation.md:

     https://github.com/OpenGenus/cosmos/blob/master/guides/documentation_guide.md

     The document style guide may not apply for your algorithm category, you must also look at specified guide under all of the directory in the category, e.g., for project euler:

     https://github.com/OpenGenus/cosmos/blob/master/code/online_challenges/src/project_euler/documentation_guide.md
-->
