### PR TITLE
Check queue size before popping

### DIFF
--- a/code/data_structures/src/minqueue/minqueue.cpp
+++ b/code/data_structures/src/minqueue/minqueue.cpp
@@ -17,9 +17,9 @@ class MinQueue {
     bool is_empty() const{
         //utilizes the size parameter that deque provides
         if (q.size() > 0){
-            return true;
+            return false; //queue is not empty
         }
-        return false;
+        return true; //queue is empty
     }
 
     int size() const{


### PR DESCRIPTION
**Fixes issue:**
Popping out empty queues causing an exception


**Changes:**
Checked the queue size before popping out the item from the queue


<!-- Make sure to look at the Style Guide for your language in guides/coding_style/language_name:

     https://github.com/OpenGenus/cosmos/tree/master/guides/coding_style

     Note: A coding style guide may not exist for your language, since this is still in beta.
-->

<!-- Make sure to look at the Documentation Style Guide in guides/documentation.md:

     https://github.com/OpenGenus/cosmos/blob/master/guides/documentation_guide.md

     The document style guide may not apply for your algorithm category, you must also look at specified guide under all of the directory in the category, e.g., for project euler:

     https://github.com/OpenGenus/cosmos/blob/master/code/online_challenges/src/project_euler/documentation_guide.md
-->
