### PR TITLE
Corrected datatype used for multiplication by 2

### DIFF
--- a/code/bit_manipulation/src/multiply_by_2/multiply_by_2.cpp
+++ b/code/bit_manipulation/src/multiply_by_2/multiply_by_2.cpp
@@ -2,7 +2,7 @@
 
 using namespace std;
 
-unsigned multiplyWith2(unsigned n) { //Since C++ 11 left signed shift left of a negative int is undefined. 
+unsigned multiplyWith2(unsigned n) { //Since C++ 11 signed shift left of a negative int is undefined. 
     return (n << 1);                 //To avoid unexpected results always use unsigned when doing a multiply by 2 
 }
 


### PR DESCRIPTION
**Fixes issue:**
Since C++ 11 signed shift left of a negative int is undefined. Always use unsigned int to avoid unexpected results

**Changes:**
Replaced int with unsigned data type

<!-- Make sure to look at the Style Guide for your language in guides/coding_style/language_name:

     https://github.com/OpenGenus/cosmos/tree/master/guides/coding_style

     Note: A coding style guide may not exist for your language, since this is still in beta.
-->

<!-- Make sure to look at the Documentation Style Guide in guides/documentation.md:

     https://github.com/OpenGenus/cosmos/blob/master/guides/documentation_guide.md

     The document style guide may not apply for your algorithm category, you must also look at specified guide under all of the directory in the category, e.g., for project euler:

     https://github.com/OpenGenus/cosmos/blob/master/code/online_challenges/src/project_euler/documentation_guide.md
-->
