### PR TITLE
Add Generic Segment Tree implementation

### DIFF
--- a/code/data_structures/src/tree/segment_tree/generic_segment_tree.cpp
+++ b/code/data_structures/src/tree/segment_tree/generic_segment_tree.cpp
@@ -5,381 +5,381 @@
  */
 
 namespace arrow {
-  /**
-   * @brief Support for two tree memory layouts is provided
-   * 
-   * binary:
-   *   - creates the segment tree as a full binary tree
-   *   - considering the tree is built over `n` elements, the segment tree would allocate
-   *     `4.n` memory for internal usage
-   * 
-   * euler_tour:
-   *   - more memory efficient than binary segment tree
-   *   - considering the tree is build over `n` elements, the segment tree would allocate
-   *     `2.n` memory for internal usage
-   * 
-   * The provided implementation defaults to binary segment tree if no template parameter is present.
-   */
-  enum class tree_memory_layout {
-    binary,
-    euler_tour
-  };
+    /**
+     * @brief Support for two tree memory layouts is provided
+     * 
+     * binary:
+     *   - creates the segment tree as a full binary tree
+     *   - considering the tree is built over `n` elements, the segment tree would allocate
+     *     `4.n` memory for internal usage
+     * 
+     * euler_tour:
+     *   - more memory efficient than binary segment tree
+     *   - considering the tree is build over `n` elements, the segment tree would allocate
+     *     `2.n` memory for internal usage
+     * 
+     * The provided implementation defaults to binary segment tree if no template parameter is present.
+     */
+    enum class tree_memory_layout {
+        binary,
+        euler_tour
+    };
 
-  /**
-   * @brief Generic Segment Tree
-   * 
-   * A segment tree allows you to perform operations on an array in an efficient manner
-   * 
-   * @tparam Type The type of values that the tree holds in its internal nodes
-   * @tparam impl_type Memory layout type
-   */
-  template <
-    class Type,
-    tree_memory_layout impl_type = tree_memory_layout::binary
-  >
-  class segment_tree {
-    private:
-      // Internal members maintained in the segment tree
-      std::vector <Type> tree;
-      
-      int base_size;
-      const std::vector <Type>& base_ref;
+    /**
+     * @brief Generic Segment Tree
+     * 
+     * A segment tree allows you to perform operations on an array in an efficient manner
+     * 
+     * @tparam Type The type of values that the tree holds in its internal nodes
+     * @tparam impl_type Memory layout type
+     */
+    template <
+        class Type,
+        tree_memory_layout impl_type = tree_memory_layout::binary
+    >
+    class segment_tree {
+        private:
+            // Internal members maintained in the segment tree
+            std::vector <Type> tree;
+            
+            int base_size;
+            const std::vector <Type>& base_ref;
 
-      Type (*combine) (const Type&, const Type&);
+            Type (*combine) (const Type&, const Type&);
 
-    public:
-      /**
-       * @brief Construct a new segment tree object
-       * 
-       * @param base_size Number of leaf nodes segment tree should have (`n` in the tree_memory_layout documentation)
-       * @param base Base of the segment tree (leaf node values)
-       * @param combine Function used to combine values of children nodes when building parent nodes
-       */
-      segment_tree (int base_size, const std::vector <Type>& base, Type (*combine) (const Type&, const Type&))
-        : base_size (base_size),
-          base_ref (base),
-          combine (combine) {
-        if constexpr (impl_type == tree_memory_layout::binary)
-          tree.resize(4 * base_size, Type{});
-        else
-          tree.resize(2 * base_size, Type{});
-        _build_impl(0, 0, base_size - 1);
-      }
+        public:
+            /**
+             * @brief Construct a new segment tree object
+             * 
+             * @param base_size Number of leaf nodes segment tree should have (`n` in the tree_memory_layout documentation)
+             * @param base Base of the segment tree (leaf node values)
+             * @param combine Function used to combine values of children nodes when building parent nodes
+             */
+            segment_tree (int base_size, const std::vector <Type>& base, Type (*combine) (const Type&, const Type&))
+                : base_size (base_size),
+                    base_ref (base),
+                    combine (combine) {
+                if constexpr (impl_type == tree_memory_layout::binary)
+                    tree.resize(4 * base_size, Type{});
+                else
+                    tree.resize(2 * base_size, Type{});
+                _build_impl(0, 0, base_size - 1);
+            }
 
-      /**
-       * @brief Point update in segment tree. Essentially performs `array[position] = value`.
-       * 
-       * @param position Index to be updated
-       * @param value Value to be set at `position`
-       */
-      void point_update (int position, const Type& value)
-      { _point_update_impl(0, 0, base_size - 1, position, value); }
+            /**
+             * @brief Point update in segment tree. Essentially performs `array[position] = value`.
+             * 
+             * @param position Index to be updated
+             * @param value Value to be set at `position`
+             */
+            void point_update (int position, const Type& value)
+            { _point_update_impl(0, 0, base_size - 1, position, value); }
 
-      /**
-       * @brief Point query in segment tree. Essentially returns `array[position]`
-       * 
-       * @param position Index to be queried
-       * @return Type `array[position]`
-       */
-      Type point_query (int position)
-      { return _point_query_impl(0, 0, base_size - 1, position); }
+            /**
+             * @brief Point query in segment tree. Essentially returns `array[position]`
+             * 
+             * @param position Index to be queried
+             * @return Type `array[position]`
+             */
+            Type point_query (int position)
+            { return _point_query_impl(0, 0, base_size - 1, position); }
 
-      /**
-       * @brief Range query in segment tree. Essentially performs the `combine` function
-       *        on the range `array[l, r]` (bounds are inclusive).
-       * 
-       * @param l Left bound of query (inclusive)
-       * @param r Right bound of query (inclusive)
-       * @return Type Result of the query based on `combine`
-       */
-      Type range_query (int l, int r)
-      { return _range_query_impl(0, 0, base_size - 1, l, r); }
+            /**
+             * @brief Range query in segment tree. Essentially performs the `combine` function
+             *        on the range `array[l, r]` (bounds are inclusive).
+             * 
+             * @param l Left bound of query (inclusive)
+             * @param r Right bound of query (inclusive)
+             * @return Type Result of the query based on `combine`
+             */
+            Type range_query (int l, int r)
+            { return _range_query_impl(0, 0, base_size - 1, l, r); }
 
-      /**
-       * @brief Custom point update in segment tree.
-       * 
-       * The implementation for this method can be added by the user if they would like
-       * to perform updates in a different sense from the norm.
-       * 
-       * @tparam ParamTypes Types of parameters that will be passed to the update implementation
-       * @param position Index to be updated
-       * @param params Parameter list required by custom update implementation
-       */
-      template <typename... ParamTypes>
-      void custom_point_update (int position, const ParamTypes&... params)
-      { _custom_point_update_impl(0, 0, base_size - 1, position, params...); }
+            /**
+             * @brief Custom point update in segment tree.
+             * 
+             * The implementation for this method can be added by the user if they would like
+             * to perform updates in a different sense from the norm.
+             * 
+             * @tparam ParamTypes Types of parameters that will be passed to the update implementation
+             * @param position Index to be updated
+             * @param params Parameter list required by custom update implementation
+             */
+            template <typename... ParamTypes>
+            void custom_point_update (int position, const ParamTypes&... params)
+            { _custom_point_update_impl(0, 0, base_size - 1, position, params...); }
 
-      /**
-       * @brief Custom point query in segment tree.
-       * 
-       * The implementation for this method can be added by the user if they would like
-       * to perform updates in a different sense from the norm.
-       * 
-       * @tparam ParamTypes Types of parameters that will be passed to the query implementation
-       * @param position Index to be queried
-       * @param params Parameter list required by custom query implementation
-       */
-      template <typename... ParamTypes>
-      Type custom_point_query (int position, const ParamTypes&... params)
-      { _custom_point_query_impl(0, 0, base_size - 1, position, params...); }
+            /**
+             * @brief Custom point query in segment tree.
+             * 
+             * The implementation for this method can be added by the user if they would like
+             * to perform updates in a different sense from the norm.
+             * 
+             * @tparam ParamTypes Types of parameters that will be passed to the query implementation
+             * @param position Index to be queried
+             * @param params Parameter list required by custom query implementation
+             */
+            template <typename... ParamTypes>
+            Type custom_point_query (int position, const ParamTypes&... params)
+            { _custom_point_query_impl(0, 0, base_size - 1, position, params...); }
 
-      /**
-       * @brief Custom query/update in segment tree.
-       * 
-       * The implementation for this method can be added by the user if they would like
-       * to perform queries in a different sense from the norm. It is very flexible with
-       * the requirements of the user.
-       * 
-       * This function is flexible in the sense that you can copy the body multiple times and rename
-       * it to achieve different functionality as per liking.
-       * 
-       * Operations like `lazy propagation` or `beats` or `persistence` have not been implemented, and
-       * have been left to the user to do as per their liking. It can be done very easily by manipulating
-       * the body of the _custom_query_impl method (and/or creating copies of this function with different
-       * names for different purposes).
-       * 
-       * @tparam ParamTypes Types of parameters that will be passed to the query/update implementation
-       * @param params Parameter list required by custom query/update implementation
-       */
-      template <typename ReturnType, typename... ParamTypes>
-      ReturnType custom_query (const ParamTypes&... params)
-      { return _custom_query_impl <ReturnType> (0, 0, base_size - 1, params...); }
+            /**
+             * @brief Custom query/update in segment tree.
+             * 
+             * The implementation for this method can be added by the user if they would like
+             * to perform queries in a different sense from the norm. It is very flexible with
+             * the requirements of the user.
+             * 
+             * This function is flexible in the sense that you can copy the body multiple times and rename
+             * it to achieve different functionality as per liking.
+             * 
+             * Operations like `lazy propagation` or `beats` or `persistence` have not been implemented, and
+             * have been left to the user to do as per their liking. It can be done very easily by manipulating
+             * the body of the _custom_query_impl method (and/or creating copies of this function with different
+             * names for different purposes).
+             * 
+             * @tparam ParamTypes Types of parameters that will be passed to the query/update implementation
+             * @param params Parameter list required by custom query/update implementation
+             */
+            template <typename ReturnType, typename... ParamTypes>
+            ReturnType custom_query (const ParamTypes&... params)
+            { return _custom_query_impl <ReturnType> (0, 0, base_size - 1, params...); }
 
-    private:
-      /**
-       * @brief Returns the index of the left child given the parent index based on
-       *        chosen tree_memory_layout
-       * 
-       * @param v Index of parent
-       * @param tl Left bound of parent
-       * @param tr Right bound of parent
-       * @return int Index of left child of parent
-       */
-      int _get_leftchild (int v, [[maybe_unused]] int tl, [[maybe_unused]] int tr) {
-        if constexpr (impl_type == tree_memory_layout::binary)
-          return 2 * v + 1;
-        else
-          return v + 1;
-      }
+        private:
+            /**
+             * @brief Returns the index of the left child given the parent index based on
+             *        chosen tree_memory_layout
+             * 
+             * @param v Index of parent
+             * @param tl Left bound of parent
+             * @param tr Right bound of parent
+             * @return int Index of left child of parent
+             */
+            int _get_leftchild (int v, [[maybe_unused]] int tl, [[maybe_unused]] int tr) {
+                if constexpr (impl_type == tree_memory_layout::binary)
+                    return 2 * v + 1;
+                else
+                    return v + 1;
+            }
 
-      /**
-       * @brief Returns the index of the right child given the parent index based on
-       *        chosen tree_memory_layout
-       * 
-       * @param v Index of parent
-       * @param tl Left bound of parent
-       * @param tr Right bound of parent
-       * @return int Index of right child of parent
-       */
-      int _get_rightchild (int v, [[maybe_unused]] int tl, [[maybe_unused]] int tr) {
-        if constexpr (impl_type == tree_memory_layout::binary)
-          return 2 * v + 2;
-        else {
-          int tm = (tl + tr) / 2;
-          int node_count = tm - tl + 1;
-          return v + 2 * node_count;
-        }
-      }
+            /**
+             * @brief Returns the index of the right child given the parent index based on
+             *        chosen tree_memory_layout
+             * 
+             * @param v Index of parent
+             * @param tl Left bound of parent
+             * @param tr Right bound of parent
+             * @return int Index of right child of parent
+             */
+            int _get_rightchild (int v, [[maybe_unused]] int tl, [[maybe_unused]] int tr) {
+                if constexpr (impl_type == tree_memory_layout::binary)
+                    return 2 * v + 2;
+                else {
+                    int tm = (tl + tr) / 2;
+                    int node_count = tm - tl + 1;
+                    return v + 2 * node_count;
+                }
+            }
 
-      /**
-       * @brief Internal function to build the segment tree
-       * 
-       * @param v Index of node where the segment tree starts to build
-       * @param tl Left bound of node
-       * @param tr Right bound of node
-       */
-      void _build_impl (int v, int tl, int tr) {
-        if (tl == tr) {
-          tree[v] = base_ref[tl];
-          return;
-        }
+            /**
+             * @brief Internal function to build the segment tree
+             * 
+             * @param v Index of node where the segment tree starts to build
+             * @param tl Left bound of node
+             * @param tr Right bound of node
+             */
+            void _build_impl (int v, int tl, int tr) {
+                if (tl == tr) {
+                    tree[v] = base_ref[tl];
+                    return;
+                }
 
-        int tm = (tl + tr) / 2;
-        int lchild = _get_leftchild(v, tl, tr);
-        int rchild = _get_rightchild(v, tl, tr);
+                int tm = (tl + tr) / 2;
+                int lchild = _get_leftchild(v, tl, tr);
+                int rchild = _get_rightchild(v, tl, tr);
 
-        _build_impl(lchild, tl, tm);
-        _build_impl(rchild, tm + 1, tr);
-        
-        tree[v] = combine(tree[lchild], tree[rchild]);
-      }
+                _build_impl(lchild, tl, tm);
+                _build_impl(rchild, tm + 1, tr);
+                
+                tree[v] = combine(tree[lchild], tree[rchild]);
+            }
 
-      /**
-       * @brief Internal implementation of point_update
-       * 
-       * @param v Current node index
-       * @param tl Current node left bound
-       * @param tr Current node right bound
-       * @param position Index to be updated
-       * @param value Value to be set at `position`
-       */
-      void _point_update_impl (int v, int tl, int tr, int position, const Type& value) {
-        if (tl == tr) {
-          tree[v] = value;
-          return;
-        }
+            /**
+             * @brief Internal implementation of point_update
+             * 
+             * @param v Current node index
+             * @param tl Current node left bound
+             * @param tr Current node right bound
+             * @param position Index to be updated
+             * @param value Value to be set at `position`
+             */
+            void _point_update_impl (int v, int tl, int tr, int position, const Type& value) {
+                if (tl == tr) {
+                    tree[v] = value;
+                    return;
+                }
 
-        int tm = (tl + tr) / 2;
-        int lchild = _get_leftchild(v, tl, tr);
-        int rchild = _get_rightchild(v, tl, tr);
-        
-        // Since we need to only update a single index, we choose the correct
-        // "side" of the segment tree to traverse to at each step
-        if (position <= tm)
-          _point_update_impl(lchild, tl, tm, position, value);
-        else
-          _point_update_impl(rchild, tm + 1, tr, position, value);
-        
-        tree[v] = combine(tree[lchild], tree[rchild]);
-      }
+                int tm = (tl + tr) / 2;
+                int lchild = _get_leftchild(v, tl, tr);
+                int rchild = _get_rightchild(v, tl, tr);
+                
+                // Since we need to only update a single index, we choose the correct
+                // "side" of the segment tree to traverse to at each step
+                if (position <= tm)
+                    _point_update_impl(lchild, tl, tm, position, value);
+                else
+                    _point_update_impl(rchild, tm + 1, tr, position, value);
+                
+                tree[v] = combine(tree[lchild], tree[rchild]);
+            }
 
-      /**
-       * @brief Internal implementation of point_query
-       * 
-       * @param v Current node index
-       * @param tl Current node left bound
-       * @param tr Current node right bound
-       * @param position Index to be updated
-       * @return Type Value to be set at `position`
-       */
-      Type _point_query_impl (int v, int tl, int tr, int position) {
-        if (tl == tr)
-          return tree[v];
-        
-        int tm = (tl + tr) / 2;
-        int lchild = _get_leftchild(v, tl, tr);
-        int rchild = _get_rightchild(v, tl, tr);
-        
-        // Since we need to only update a single index, we choose the correct
-        // "side" of the segment tree to traverse to at each step
-        if (position <= tm)
-          return _point_query_impl(lchild, tl, tm, position);
-        else
-          return _point_query_impl(rchild, tm + 1, tr, position);
-      }
+            /**
+             * @brief Internal implementation of point_query
+             * 
+             * @param v Current node index
+             * @param tl Current node left bound
+             * @param tr Current node right bound
+             * @param position Index to be updated
+             * @return Type Value to be set at `position`
+             */
+            Type _point_query_impl (int v, int tl, int tr, int position) {
+                if (tl == tr)
+                    return tree[v];
+                
+                int tm = (tl + tr) / 2;
+                int lchild = _get_leftchild(v, tl, tr);
+                int rchild = _get_rightchild(v, tl, tr);
+                
+                // Since we need to only update a single index, we choose the correct
+                // "side" of the segment tree to traverse to at each step
+                if (position <= tm)
+                    return _point_query_impl(lchild, tl, tm, position);
+                else
+                    return _point_query_impl(rchild, tm + 1, tr, position);
+            }
 
-      /**
-       * @brief Internal implementation of range_query
-       * 
-       * @param v Current node index
-       * @param tl Current node left bound
-       * @param tr Current node right bound
-       * @param l Current query left bound
-       * @param r Current query right bound
-       * @return Type Result of the query
-       */
-      Type _range_query_impl (int v, int tl, int tr, int l, int r) {
-        // We are out of bounds in our search
-        // Return a sentinel value which must be defaulted in the constuctor of Type
-        if (l > r)
-          return {};
-        
-        // We have found the correct range for the query
-        // Return the value at current node because it's not required to process further
-        if (tl == l and tr == r)
-          return tree[v];
-        
-        int tm = (tl + tr) / 2;
-        int lchild = _get_leftchild(v, tl, tr);
-        int rchild = _get_rightchild(v, tl, tr);
+            /**
+             * @brief Internal implementation of range_query
+             * 
+             * @param v Current node index
+             * @param tl Current node left bound
+             * @param tr Current node right bound
+             * @param l Current query left bound
+             * @param r Current query right bound
+             * @return Type Result of the query
+             */
+            Type _range_query_impl (int v, int tl, int tr, int l, int r) {
+                // We are out of bounds in our search
+                // Return a sentinel value which must be defaulted in the constuctor of Type
+                if (l > r)
+                    return {};
+                
+                // We have found the correct range for the query
+                // Return the value at current node because it's not required to process further
+                if (tl == l and tr == r)
+                    return tree[v];
+                
+                int tm = (tl + tr) / 2;
+                int lchild = _get_leftchild(v, tl, tr);
+                int rchild = _get_rightchild(v, tl, tr);
 
-        // We have not yet found the correct range for the query
-        // Get results of left child and right child and combine
-        Type lval = _range_query_impl(lchild, tl, tm, l, std::min(r, tm));
-        Type rval = _range_query_impl(rchild, tm + 1, tr, std::max(l, tm + 1), r);
-        
-        return combine(lval, rval);
-      }
+                // We have not yet found the correct range for the query
+                // Get results of left child and right child and combine
+                Type lval = _range_query_impl(lchild, tl, tm, l, std::min(r, tm));
+                Type rval = _range_query_impl(rchild, tm + 1, tr, std::max(l, tm + 1), r);
+                
+                return combine(lval, rval);
+            }
 
-      /**
-       * @brief Internal implementation of custom_point_update
-       * 
-       * Note that you need to change the definition of this function if you're passing
-       * any variadic argument list in custom_point_update
-       * 
-       * @param v Current node index
-       * @param tl Current node left bound
-       * @param tr Current node right bound
-       * @param position Index to be updated
-       */
-      void _custom_point_update_impl (int v, int tl, int tr, int position) {
-        if (tl == tr) {
-          throw std::runtime_error("undefined implementation");
-          return;
-        }
+            /**
+             * @brief Internal implementation of custom_point_update
+             * 
+             * Note that you need to change the definition of this function if you're passing
+             * any variadic argument list in custom_point_update
+             * 
+             * @param v Current node index
+             * @param tl Current node left bound
+             * @param tr Current node right bound
+             * @param position Index to be updated
+             */
+            void _custom_point_update_impl (int v, int tl, int tr, int position) {
+                if (tl == tr) {
+                    throw std::runtime_error("undefined implementation");
+                    return;
+                }
 
-        int tm = (tl + tr) / 2;
-        int lchild = _get_leftchild(v, tl, tr);
-        int rchild = _get_rightchild(v, tl, tr);
+                int tm = (tl + tr) / 2;
+                int lchild = _get_leftchild(v, tl, tr);
+                int rchild = _get_rightchild(v, tl, tr);
 
-        // Since we need to only update a single index, we choose the correct
-        // "side" of the segment tree to traverse to at each step
-        if (position <= tm)
-          _custom_point_update_impl(lchild, tl, tm, position);
-        else
-          _custom_point_update_impl(rchild, tm + 1, tr, position);
-        
-        tree[v] = combine(tree[lchild], tree[rchild]);
-      }
+                // Since we need to only update a single index, we choose the correct
+                // "side" of the segment tree to traverse to at each step
+                if (position <= tm)
+                    _custom_point_update_impl(lchild, tl, tm, position);
+                else
+                    _custom_point_update_impl(rchild, tm + 1, tr, position);
+                
+                tree[v] = combine(tree[lchild], tree[rchild]);
+            }
 
-      /**
-       * @brief Internal implementation of custom_point_query
-       * 
-       * Note that you need to change the definition of this function if you're passing
-       * any variadic argument list in custom_point_query
-       * 
-       * @param v Current node index
-       * @param tl Current node left bound
-       * @param tr Current node right bound
-       * @param position Index to be queried
-       * @return Type Result of the query
-       */
-      Type _custom_point_query_impl (int v, int tl, int tr, int position) {
-        if (tl == tr) {
-          throw std::runtime_error("undefined implementation");
-          return {};
-        }
+            /**
+             * @brief Internal implementation of custom_point_query
+             * 
+             * Note that you need to change the definition of this function if you're passing
+             * any variadic argument list in custom_point_query
+             * 
+             * @param v Current node index
+             * @param tl Current node left bound
+             * @param tr Current node right bound
+             * @param position Index to be queried
+             * @return Type Result of the query
+             */
+            Type _custom_point_query_impl (int v, int tl, int tr, int position) {
+                if (tl == tr) {
+                    throw std::runtime_error("undefined implementation");
+                    return {};
+                }
 
-        int tm = (tl + tr) / 2;
-        int lchild = _get_leftchild(v, tl, tr);
-        int rchild = _get_rightchild(v, tl, tr);
+                int tm = (tl + tr) / 2;
+                int lchild = _get_leftchild(v, tl, tr);
+                int rchild = _get_rightchild(v, tl, tr);
 
-        // Since we need to only update a single index, we choose the correct
-        // "side" of the segment tree to traverse to at each step
-        if (position <= tm)
-          return _custom_point_query_impl(lchild, tl, tm, position);
-        else
-          return _custom_point_query_impl(rchild, tm + 1, tr, position);
-      }
+                // Since we need to only update a single index, we choose the correct
+                // "side" of the segment tree to traverse to at each step
+                if (position <= tm)
+                    return _custom_point_query_impl(lchild, tl, tm, position);
+                else
+                    return _custom_point_query_impl(rchild, tm + 1, tr, position);
+            }
 
-      /**
-       * @brief Internal implementation of custom_query
-       * 
-       * The user can create multiple copies with different names for this function and make
-       * calls accordingly. Read the documentation for custom_query above.
-       * 
-       * @tparam ReturnType Return type of the custom query/update
-       * @param v Current node index
-       * @param tl Current node left bound
-       * @param tr Current node right bound
-       * @return ReturnType Return value of the custom query/update
-       */
-      template <typename ReturnType>
-      ReturnType _custom_query_impl (int v, int tl, int tr) {
-        if (tl == tr) {
-          throw std::runtime_error("undefined implementation");
-          return ReturnType{};
-        }
-        
-        int tm = (tl + tr) / 2;
-        int lchild = _get_leftchild(v, tl, tr);
-        int rchild = _get_rightchild(v, tl, tr);
+            /**
+             * @brief Internal implementation of custom_query
+             * 
+             * The user can create multiple copies with different names for this function and make
+             * calls accordingly. Read the documentation for custom_query above.
+             * 
+             * @tparam ReturnType Return type of the custom query/update
+             * @param v Current node index
+             * @param tl Current node left bound
+             * @param tr Current node right bound
+             * @return ReturnType Return value of the custom query/update
+             */
+            template <typename ReturnType>
+            ReturnType _custom_query_impl (int v, int tl, int tr) {
+                if (tl == tr) {
+                    throw std::runtime_error("undefined implementation");
+                    return ReturnType{};
+                }
+                
+                int tm = (tl + tr) / 2;
+                int lchild = _get_leftchild(v, tl, tr);
+                int rchild = _get_rightchild(v, tl, tr);
 
-        // Change functionality as per liking
-        if (true)
-          return _custom_query_impl <ReturnType> (lchild, tl, tm);
-        else
-          return _custom_query_impl <ReturnType> (rchild, tm + 1, tr);
-      }
-  };
+                // Change functionality as per liking
+                if (true)
+                    return _custom_query_impl <ReturnType> (lchild, tl, tm);
+                else
+                    return _custom_query_impl <ReturnType> (rchild, tm + 1, tr);
+            }
+    };
 };

--- a/code/data_structures/src/tree/segment_tree/generic_segment_tree.cpp
+++ b/code/data_structures/src/tree/segment_tree/generic_segment_tree.cpp
@@ -8,21 +8,21 @@ namespace arrow {
     /**
      * @brief Support for two tree memory layouts is provided
      * 
-     * binary:
-     *   - creates the segment tree as a full binary tree
+     * Binary:
+     *   - creates the segment tree as a full Binary tree
      *   - considering the tree is built over `n` elements, the segment tree would allocate
      *     `4.n` memory for internal usage
      * 
-     * euler_tour:
-     *   - more memory efficient than binary segment tree
+     * EulerTour:
+     *   - more memory efficient than Binary segment tree
      *   - considering the tree is build over `n` elements, the segment tree would allocate
      *     `2.n` memory for internal usage
      * 
-     * The provided implementation defaults to binary segment tree if no template parameter is present.
+     * The provided implementation defaults to Binary segment tree if no template parameter is present.
      */
-    enum class tree_memory_layout {
-        binary,
-        euler_tour
+    enum class TreeMemoryLayout {
+        Binary,
+        EulerTour
     };
 
     /**
@@ -35,351 +35,351 @@ namespace arrow {
      */
     template <
         class Type,
-        tree_memory_layout impl_type = tree_memory_layout::binary
+        TreeMemoryLayout impl_type = TreeMemoryLayout::Binary
     >
-    class segment_tree {
-        private:
-            // Internal members maintained in the segment tree
-            std::vector <Type> tree;
+    class SegmentTree {
+    private:
+        // Internal members maintained in the segment tree
+        std::vector <Type> tree_;
+        
+        int base_size_;
+        const std::vector <Type>& base_ref_;
+
+        Type (*combine_) (const Type&, const Type&);
+
+    public:
+        /**
+         * @brief Construct a new segment tree object
+         * 
+         * @param base_size_ Number of leaf nodes segment tree should have (`n` in the tree_memory_layout documentation)
+         * @param base Base of the segment tree (leaf node values)
+         * @param combine_ Function used to combine_ values of children nodes when building parent nodes
+         */
+        SegmentTree (int base_size, const std::vector <Type>& base, Type (*combine) (const Type&, const Type&))
+            : base_size_ (base_size),
+              base_ref_ (base),
+              combine_ (combine) {
+            if constexpr (impl_type == TreeMemoryLayout::Binary)
+                tree_.resize(4 * base_size_, Type{});
+            else
+                tree_.resize(2 * base_size_, Type{});
+            _build_impl(0, 0, base_size_ - 1);
+        }
+
+        /**
+         * @brief Point update in segment tree. Essentially performs `array[position] = value`.
+         * 
+         * @param position Index to be updated
+         * @param value Value to be set at `position`
+         */
+        void pointUpdate (int position, const Type& value)
+        { _point_update_impl(0, 0, base_size_ - 1, position, value); }
+
+        /**
+         * @brief Point query in segment tree. Essentially returns `array[position]`
+         * 
+         * @param position Index to be queried
+         * @return Type `array[position]`
+         */
+        Type pointQuery (int position)
+        { return _point_query_impl(0, 0, base_size_ - 1, position); }
+
+        /**
+         * @brief Range query in segment tree. Essentially performs the `combine_` function
+         *        on the range `array[l, r]` (bounds are inclusive).
+         * 
+         * @param l Left bound of query (inclusive)
+         * @param r Right bound of query (inclusive)
+         * @return Type Result of the query based on `combine_`
+         */
+        Type rangeQuery (int l, int r)
+        { return _range_query_impl(0, 0, base_size_ - 1, l, r); }
+
+        /**
+         * @brief Custom point update in segment tree.
+         * 
+         * The implementation for this method can be added by the user if they would like
+         * to perform updates in a different sense from the norm.
+         * 
+         * @tparam ParamTypes Types of parameters that will be passed to the update implementation
+         * @param position Index to be updated
+         * @param params Parameter list required by custom update implementation
+         */
+        template <typename... ParamTypes>
+        void customPointUpdate (int position, const ParamTypes&... params)
+        { _custom_point_update_impl(0, 0, base_size_ - 1, position, params...); }
+
+        /**
+         * @brief Custom point query in segment tree.
+         * 
+         * The implementation for this method can be added by the user if they would like
+         * to perform updates in a different sense from the norm.
+         * 
+         * @tparam ParamTypes Types of parameters that will be passed to the query implementation
+         * @param position Index to be queried
+         * @param params Parameter list required by custom query implementation
+         */
+        template <typename... ParamTypes>
+        Type customPointQuery (int position, const ParamTypes&... params)
+        { _custom_point_query_impl(0, 0, base_size_ - 1, position, params...); }
+
+        /**
+         * @brief Custom query/update in segment tree.
+         * 
+         * The implementation for this method can be added by the user if they would like
+         * to perform queries in a different sense from the norm. It is very flexible with
+         * the requirements of the user.
+         * 
+         * This function is flexible in the sense that you can copy the body multiple times and rename
+         * it to achieve different functionality as per liking.
+         * 
+         * Operations like `lazy propagation` or `beats` or `persistence` have not been implemented, and
+         * have been left to the user to do as per their liking. It can be done very easily by manipulating
+         * the body of the _custom_query_impl method (and/or creating copies of this function with different
+         * names for different purposes).
+         * 
+         * @tparam ParamTypes Types of parameters that will be passed to the query/update implementation
+         * @param params Parameter list required by custom query/update implementation
+         */
+        template <typename ReturnType, typename... ParamTypes>
+        ReturnType customQuery (const ParamTypes&... params)
+        { return _custom_query_impl <ReturnType> (0, 0, base_size_ - 1, params...); }
+
+    private:
+        /**
+         * @brief Returns the index of the left child given the parent index based on
+         *        chosen tree_memory_layout
+         * 
+         * @param v Index of parent
+         * @param tl Left bound of parent
+         * @param tr Right bound of parent
+         * @return int Index of left child of parent
+         */
+        int _get_leftchild (int v, [[maybe_unused]] int tl, [[maybe_unused]] int tr) {
+            if constexpr (impl_type == TreeMemoryLayout::Binary)
+                return 2 * v + 1;
+            else
+                return v + 1;
+        }
+
+        /**
+         * @brief Returns the index of the right child given the parent index based on
+         *        chosen tree_memory_layout
+         * 
+         * @param v Index of parent
+         * @param tl Left bound of parent
+         * @param tr Right bound of parent
+         * @return int Index of right child of parent
+         */
+        int _get_rightchild (int v, [[maybe_unused]] int tl, [[maybe_unused]] int tr) {
+            if constexpr (impl_type == TreeMemoryLayout::Binary)
+                return 2 * v + 2;
+            else {
+                int tm = (tl + tr) / 2;
+                int node_count = tm - tl + 1;
+                return v + 2 * node_count;
+            }
+        }
+
+        /**
+         * @brief Internal function to build the segment tree
+         * 
+         * @param v Index of node where the segment tree starts to build
+         * @param tl Left bound of node
+         * @param tr Right bound of node
+         */
+        void _build_impl (int v, int tl, int tr) {
+            if (tl == tr) {
+                tree_[v] = base_ref_[tl];
+                return;
+            }
+
+            int tm = (tl + tr) / 2;
+            int lchild = _get_leftchild(v, tl, tr);
+            int rchild = _get_rightchild(v, tl, tr);
+
+            _build_impl(lchild, tl, tm);
+            _build_impl(rchild, tm + 1, tr);
             
-            int base_size;
-            const std::vector <Type>& base_ref;
+            tree_[v] = combine_(tree_[lchild], tree_[rchild]);
+        }
 
-            Type (*combine) (const Type&, const Type&);
-
-        public:
-            /**
-             * @brief Construct a new segment tree object
-             * 
-             * @param base_size Number of leaf nodes segment tree should have (`n` in the tree_memory_layout documentation)
-             * @param base Base of the segment tree (leaf node values)
-             * @param combine Function used to combine values of children nodes when building parent nodes
-             */
-            segment_tree (int base_size, const std::vector <Type>& base, Type (*combine) (const Type&, const Type&))
-                : base_size (base_size),
-                    base_ref (base),
-                    combine (combine) {
-                if constexpr (impl_type == tree_memory_layout::binary)
-                    tree.resize(4 * base_size, Type{});
-                else
-                    tree.resize(2 * base_size, Type{});
-                _build_impl(0, 0, base_size - 1);
+        /**
+         * @brief Internal implementation of point_update
+         * 
+         * @param v Current node index
+         * @param tl Current node left bound
+         * @param tr Current node right bound
+         * @param position Index to be updated
+         * @param value Value to be set at `position`
+         */
+        void _point_update_impl (int v, int tl, int tr, int position, const Type& value) {
+            if (tl == tr) {
+                tree_[v] = value;
+                return;
             }
 
-            /**
-             * @brief Point update in segment tree. Essentially performs `array[position] = value`.
-             * 
-             * @param position Index to be updated
-             * @param value Value to be set at `position`
-             */
-            void point_update (int position, const Type& value)
-            { _point_update_impl(0, 0, base_size - 1, position, value); }
+            int tm = (tl + tr) / 2;
+            int lchild = _get_leftchild(v, tl, tr);
+            int rchild = _get_rightchild(v, tl, tr);
+            
+            // Since we need to only update a single index, we choose the correct
+            // "side" of the segment tree to traverse to at each step
+            if (position <= tm)
+                _point_update_impl(lchild, tl, tm, position, value);
+            else
+                _point_update_impl(rchild, tm + 1, tr, position, value);
+            
+            tree_[v] = combine_(tree_[lchild], tree_[rchild]);
+        }
 
-            /**
-             * @brief Point query in segment tree. Essentially returns `array[position]`
-             * 
-             * @param position Index to be queried
-             * @return Type `array[position]`
-             */
-            Type point_query (int position)
-            { return _point_query_impl(0, 0, base_size - 1, position); }
+        /**
+         * @brief Internal implementation of point_query
+         * 
+         * @param v Current node index
+         * @param tl Current node left bound
+         * @param tr Current node right bound
+         * @param position Index to be updated
+         * @return Type Value to be set at `position`
+         */
+        Type _point_query_impl (int v, int tl, int tr, int position) {
+            if (tl == tr)
+                return tree_[v];
+            
+            int tm = (tl + tr) / 2;
+            int lchild = _get_leftchild(v, tl, tr);
+            int rchild = _get_rightchild(v, tl, tr);
+            
+            // Since we need to only update a single index, we choose the correct
+            // "side" of the segment tree to traverse to at each step
+            if (position <= tm)
+                return _point_query_impl(lchild, tl, tm, position);
+            else
+                return _point_query_impl(rchild, tm + 1, tr, position);
+        }
 
-            /**
-             * @brief Range query in segment tree. Essentially performs the `combine` function
-             *        on the range `array[l, r]` (bounds are inclusive).
-             * 
-             * @param l Left bound of query (inclusive)
-             * @param r Right bound of query (inclusive)
-             * @return Type Result of the query based on `combine`
-             */
-            Type range_query (int l, int r)
-            { return _range_query_impl(0, 0, base_size - 1, l, r); }
+        /**
+         * @brief Internal implementation of rangeQuery
+         * 
+         * @param v Current node index
+         * @param tl Current node left bound
+         * @param tr Current node right bound
+         * @param l Current query left bound
+         * @param r Current query right bound
+         * @return Type Result of the query
+         */
+        Type _range_query_impl (int v, int tl, int tr, int l, int r) {
+            // We are out of bounds in our search
+            // Return a sentinel value which must be defaulted in the constuctor of Type
+            if (l > r)
+                return {};
+            
+            // We have found the correct range for the query
+            // Return the value at current node because it's not required to process further
+            if (tl == l and tr == r)
+                return tree_[v];
+            
+            int tm = (tl + tr) / 2;
+            int lchild = _get_leftchild(v, tl, tr);
+            int rchild = _get_rightchild(v, tl, tr);
 
-            /**
-             * @brief Custom point update in segment tree.
-             * 
-             * The implementation for this method can be added by the user if they would like
-             * to perform updates in a different sense from the norm.
-             * 
-             * @tparam ParamTypes Types of parameters that will be passed to the update implementation
-             * @param position Index to be updated
-             * @param params Parameter list required by custom update implementation
-             */
-            template <typename... ParamTypes>
-            void custom_point_update (int position, const ParamTypes&... params)
-            { _custom_point_update_impl(0, 0, base_size - 1, position, params...); }
+            // We have not yet found the correct range for the query
+            // Get results of left child and right child and combine_
+            Type lval = _range_query_impl(lchild, tl, tm, l, std::min(r, tm));
+            Type rval = _range_query_impl(rchild, tm + 1, tr, std::max(l, tm + 1), r);
+            
+            return combine_(lval, rval);
+        }
 
-            /**
-             * @brief Custom point query in segment tree.
-             * 
-             * The implementation for this method can be added by the user if they would like
-             * to perform updates in a different sense from the norm.
-             * 
-             * @tparam ParamTypes Types of parameters that will be passed to the query implementation
-             * @param position Index to be queried
-             * @param params Parameter list required by custom query implementation
-             */
-            template <typename... ParamTypes>
-            Type custom_point_query (int position, const ParamTypes&... params)
-            { _custom_point_query_impl(0, 0, base_size - 1, position, params...); }
-
-            /**
-             * @brief Custom query/update in segment tree.
-             * 
-             * The implementation for this method can be added by the user if they would like
-             * to perform queries in a different sense from the norm. It is very flexible with
-             * the requirements of the user.
-             * 
-             * This function is flexible in the sense that you can copy the body multiple times and rename
-             * it to achieve different functionality as per liking.
-             * 
-             * Operations like `lazy propagation` or `beats` or `persistence` have not been implemented, and
-             * have been left to the user to do as per their liking. It can be done very easily by manipulating
-             * the body of the _custom_query_impl method (and/or creating copies of this function with different
-             * names for different purposes).
-             * 
-             * @tparam ParamTypes Types of parameters that will be passed to the query/update implementation
-             * @param params Parameter list required by custom query/update implementation
-             */
-            template <typename ReturnType, typename... ParamTypes>
-            ReturnType custom_query (const ParamTypes&... params)
-            { return _custom_query_impl <ReturnType> (0, 0, base_size - 1, params...); }
-
-        private:
-            /**
-             * @brief Returns the index of the left child given the parent index based on
-             *        chosen tree_memory_layout
-             * 
-             * @param v Index of parent
-             * @param tl Left bound of parent
-             * @param tr Right bound of parent
-             * @return int Index of left child of parent
-             */
-            int _get_leftchild (int v, [[maybe_unused]] int tl, [[maybe_unused]] int tr) {
-                if constexpr (impl_type == tree_memory_layout::binary)
-                    return 2 * v + 1;
-                else
-                    return v + 1;
+        /**
+         * @brief Internal implementation of customPointUpdate
+         * 
+         * Note that you need to change the definition of this function if you're passing
+         * any variadic argument list in customPointUpdate
+         * 
+         * @param v Current node index
+         * @param tl Current node left bound
+         * @param tr Current node right bound
+         * @param position Index to be updated
+         */
+        void _custom_point_update_impl (int v, int tl, int tr, int position) {
+            if (tl == tr) {
+                throw std::runtime_error("undefined implementation");
+                return;
             }
 
-            /**
-             * @brief Returns the index of the right child given the parent index based on
-             *        chosen tree_memory_layout
-             * 
-             * @param v Index of parent
-             * @param tl Left bound of parent
-             * @param tr Right bound of parent
-             * @return int Index of right child of parent
-             */
-            int _get_rightchild (int v, [[maybe_unused]] int tl, [[maybe_unused]] int tr) {
-                if constexpr (impl_type == tree_memory_layout::binary)
-                    return 2 * v + 2;
-                else {
-                    int tm = (tl + tr) / 2;
-                    int node_count = tm - tl + 1;
-                    return v + 2 * node_count;
-                }
+            int tm = (tl + tr) / 2;
+            int lchild = _get_leftchild(v, tl, tr);
+            int rchild = _get_rightchild(v, tl, tr);
+
+            // Since we need to only update a single index, we choose the correct
+            // "side" of the segment tree to traverse to at each step
+            if (position <= tm)
+                _custom_point_update_impl(lchild, tl, tm, position);
+            else
+                _custom_point_update_impl(rchild, tm + 1, tr, position);
+            
+            tree_[v] = combine_(tree_[lchild], tree_[rchild]);
+        }
+
+        /**
+         * @brief Internal implementation of customPointQuery
+         * 
+         * Note that you need to change the definition of this function if you're passing
+         * any variadic argument list in customPointQuery
+         * 
+         * @param v Current node index
+         * @param tl Current node left bound
+         * @param tr Current node right bound
+         * @param position Index to be queried
+         * @return Type Result of the query
+         */
+        Type _custom_point_query_impl (int v, int tl, int tr, int position) {
+            if (tl == tr) {
+                throw std::runtime_error("undefined implementation");
+                return {};
             }
 
-            /**
-             * @brief Internal function to build the segment tree
-             * 
-             * @param v Index of node where the segment tree starts to build
-             * @param tl Left bound of node
-             * @param tr Right bound of node
-             */
-            void _build_impl (int v, int tl, int tr) {
-                if (tl == tr) {
-                    tree[v] = base_ref[tl];
-                    return;
-                }
+            int tm = (tl + tr) / 2;
+            int lchild = _get_leftchild(v, tl, tr);
+            int rchild = _get_rightchild(v, tl, tr);
 
-                int tm = (tl + tr) / 2;
-                int lchild = _get_leftchild(v, tl, tr);
-                int rchild = _get_rightchild(v, tl, tr);
+            // Since we need to only update a single index, we choose the correct
+            // "side" of the segment tree to traverse to at each step
+            if (position <= tm)
+                return _custom_point_query_impl(lchild, tl, tm, position);
+            else
+                return _custom_point_query_impl(rchild, tm + 1, tr, position);
+        }
 
-                _build_impl(lchild, tl, tm);
-                _build_impl(rchild, tm + 1, tr);
-                
-                tree[v] = combine(tree[lchild], tree[rchild]);
+        /**
+         * @brief Internal implementation of customQuery
+         * 
+         * The user can create multiple copies with different names for this function and make
+         * calls accordingly. Read the documentation for customQuery above.
+         * 
+         * @tparam ReturnType Return type of the custom query/update
+         * @param v Current node index
+         * @param tl Current node left bound
+         * @param tr Current node right bound
+         * @return ReturnType Return value of the custom query/update
+         */
+        template <typename ReturnType>
+        ReturnType _custom_query_impl (int v, int tl, int tr) {
+            if (tl == tr) {
+                throw std::runtime_error("undefined implementation");
+                return ReturnType{};
             }
+            
+            int tm = (tl + tr) / 2;
+            int lchild = _get_leftchild(v, tl, tr);
+            int rchild = _get_rightchild(v, tl, tr);
 
-            /**
-             * @brief Internal implementation of point_update
-             * 
-             * @param v Current node index
-             * @param tl Current node left bound
-             * @param tr Current node right bound
-             * @param position Index to be updated
-             * @param value Value to be set at `position`
-             */
-            void _point_update_impl (int v, int tl, int tr, int position, const Type& value) {
-                if (tl == tr) {
-                    tree[v] = value;
-                    return;
-                }
-
-                int tm = (tl + tr) / 2;
-                int lchild = _get_leftchild(v, tl, tr);
-                int rchild = _get_rightchild(v, tl, tr);
-                
-                // Since we need to only update a single index, we choose the correct
-                // "side" of the segment tree to traverse to at each step
-                if (position <= tm)
-                    _point_update_impl(lchild, tl, tm, position, value);
-                else
-                    _point_update_impl(rchild, tm + 1, tr, position, value);
-                
-                tree[v] = combine(tree[lchild], tree[rchild]);
-            }
-
-            /**
-             * @brief Internal implementation of point_query
-             * 
-             * @param v Current node index
-             * @param tl Current node left bound
-             * @param tr Current node right bound
-             * @param position Index to be updated
-             * @return Type Value to be set at `position`
-             */
-            Type _point_query_impl (int v, int tl, int tr, int position) {
-                if (tl == tr)
-                    return tree[v];
-                
-                int tm = (tl + tr) / 2;
-                int lchild = _get_leftchild(v, tl, tr);
-                int rchild = _get_rightchild(v, tl, tr);
-                
-                // Since we need to only update a single index, we choose the correct
-                // "side" of the segment tree to traverse to at each step
-                if (position <= tm)
-                    return _point_query_impl(lchild, tl, tm, position);
-                else
-                    return _point_query_impl(rchild, tm + 1, tr, position);
-            }
-
-            /**
-             * @brief Internal implementation of range_query
-             * 
-             * @param v Current node index
-             * @param tl Current node left bound
-             * @param tr Current node right bound
-             * @param l Current query left bound
-             * @param r Current query right bound
-             * @return Type Result of the query
-             */
-            Type _range_query_impl (int v, int tl, int tr, int l, int r) {
-                // We are out of bounds in our search
-                // Return a sentinel value which must be defaulted in the constuctor of Type
-                if (l > r)
-                    return {};
-                
-                // We have found the correct range for the query
-                // Return the value at current node because it's not required to process further
-                if (tl == l and tr == r)
-                    return tree[v];
-                
-                int tm = (tl + tr) / 2;
-                int lchild = _get_leftchild(v, tl, tr);
-                int rchild = _get_rightchild(v, tl, tr);
-
-                // We have not yet found the correct range for the query
-                // Get results of left child and right child and combine
-                Type lval = _range_query_impl(lchild, tl, tm, l, std::min(r, tm));
-                Type rval = _range_query_impl(rchild, tm + 1, tr, std::max(l, tm + 1), r);
-                
-                return combine(lval, rval);
-            }
-
-            /**
-             * @brief Internal implementation of custom_point_update
-             * 
-             * Note that you need to change the definition of this function if you're passing
-             * any variadic argument list in custom_point_update
-             * 
-             * @param v Current node index
-             * @param tl Current node left bound
-             * @param tr Current node right bound
-             * @param position Index to be updated
-             */
-            void _custom_point_update_impl (int v, int tl, int tr, int position) {
-                if (tl == tr) {
-                    throw std::runtime_error("undefined implementation");
-                    return;
-                }
-
-                int tm = (tl + tr) / 2;
-                int lchild = _get_leftchild(v, tl, tr);
-                int rchild = _get_rightchild(v, tl, tr);
-
-                // Since we need to only update a single index, we choose the correct
-                // "side" of the segment tree to traverse to at each step
-                if (position <= tm)
-                    _custom_point_update_impl(lchild, tl, tm, position);
-                else
-                    _custom_point_update_impl(rchild, tm + 1, tr, position);
-                
-                tree[v] = combine(tree[lchild], tree[rchild]);
-            }
-
-            /**
-             * @brief Internal implementation of custom_point_query
-             * 
-             * Note that you need to change the definition of this function if you're passing
-             * any variadic argument list in custom_point_query
-             * 
-             * @param v Current node index
-             * @param tl Current node left bound
-             * @param tr Current node right bound
-             * @param position Index to be queried
-             * @return Type Result of the query
-             */
-            Type _custom_point_query_impl (int v, int tl, int tr, int position) {
-                if (tl == tr) {
-                    throw std::runtime_error("undefined implementation");
-                    return {};
-                }
-
-                int tm = (tl + tr) / 2;
-                int lchild = _get_leftchild(v, tl, tr);
-                int rchild = _get_rightchild(v, tl, tr);
-
-                // Since we need to only update a single index, we choose the correct
-                // "side" of the segment tree to traverse to at each step
-                if (position <= tm)
-                    return _custom_point_query_impl(lchild, tl, tm, position);
-                else
-                    return _custom_point_query_impl(rchild, tm + 1, tr, position);
-            }
-
-            /**
-             * @brief Internal implementation of custom_query
-             * 
-             * The user can create multiple copies with different names for this function and make
-             * calls accordingly. Read the documentation for custom_query above.
-             * 
-             * @tparam ReturnType Return type of the custom query/update
-             * @param v Current node index
-             * @param tl Current node left bound
-             * @param tr Current node right bound
-             * @return ReturnType Return value of the custom query/update
-             */
-            template <typename ReturnType>
-            ReturnType _custom_query_impl (int v, int tl, int tr) {
-                if (tl == tr) {
-                    throw std::runtime_error("undefined implementation");
-                    return ReturnType{};
-                }
-                
-                int tm = (tl + tr) / 2;
-                int lchild = _get_leftchild(v, tl, tr);
-                int rchild = _get_rightchild(v, tl, tr);
-
-                // Change functionality as per liking
-                if (true)
-                    return _custom_query_impl <ReturnType> (lchild, tl, tm);
-                else
-                    return _custom_query_impl <ReturnType> (rchild, tm + 1, tr);
-            }
+            // Change functionality as per liking
+            if (true)
+                return _custom_query_impl <ReturnType> (lchild, tl, tm);
+            else
+                return _custom_query_impl <ReturnType> (rchild, tm + 1, tr);
+        }
     };
 };

--- a/code/data_structures/src/tree/segment_tree/generic_segment_tree.cpp
+++ b/code/data_structures/src/tree/segment_tree/generic_segment_tree.cpp
@@ -1,0 +1,385 @@
+/**
+ * @file generic_segment_tree.cpp
+ * @author Aryan V S (https://github.com/a-r-r-o-w)
+ * @brief Implementation of a Generic Segment Tree
+ */
+
+namespace arrow {
+  /**
+   * @brief Support for two tree memory layouts is provided
+   * 
+   * binary:
+   *   - creates the segment tree as a full binary tree
+   *   - considering the tree is built over `n` elements, the segment tree would allocate
+   *     `4.n` memory for internal usage
+   * 
+   * euler_tour:
+   *   - more memory efficient than binary segment tree
+   *   - considering the tree is build over `n` elements, the segment tree would allocate
+   *     `2.n` memory for internal usage
+   * 
+   * The provided implementation defaults to binary segment tree if no template parameter is present.
+   */
+  enum class tree_memory_layout {
+    binary,
+    euler_tour
+  };
+
+  /**
+   * @brief Generic Segment Tree
+   * 
+   * A segment tree allows you to perform operations on an array in an efficient manner
+   * 
+   * @tparam Type The type of values that the tree holds in its internal nodes
+   * @tparam impl_type Memory layout type
+   */
+  template <
+    class Type,
+    tree_memory_layout impl_type = tree_memory_layout::binary
+  >
+  class segment_tree {
+    private:
+      // Internal members maintained in the segment tree
+      std::vector <Type> tree;
+      
+      int base_size;
+      const std::vector <Type>& base_ref;
+
+      Type (*combine) (const Type&, const Type&);
+
+    public:
+      /**
+       * @brief Construct a new segment tree object
+       * 
+       * @param base_size Number of leaf nodes segment tree should have (`n` in the tree_memory_layout documentation)
+       * @param base Base of the segment tree (leaf node values)
+       * @param combine Function used to combine values of children nodes when building parent nodes
+       */
+      segment_tree (int base_size, const std::vector <Type>& base, Type (*combine) (const Type&, const Type&))
+        : base_size (base_size),
+          base_ref (base),
+          combine (combine) {
+        if constexpr (impl_type == tree_memory_layout::binary)
+          tree.resize(4 * base_size, Type{});
+        else
+          tree.resize(2 * base_size, Type{});
+        _build_impl(0, 0, base_size - 1);
+      }
+
+      /**
+       * @brief Point update in segment tree. Essentially performs `array[position] = value`.
+       * 
+       * @param position Index to be updated
+       * @param value Value to be set at `position`
+       */
+      void point_update (int position, const Type& value)
+      { _point_update_impl(0, 0, base_size - 1, position, value); }
+
+      /**
+       * @brief Point query in segment tree. Essentially returns `array[position]`
+       * 
+       * @param position Index to be queried
+       * @return Type `array[position]`
+       */
+      Type point_query (int position)
+      { return _point_query_impl(0, 0, base_size - 1, position); }
+
+      /**
+       * @brief Range query in segment tree. Essentially performs the `combine` function
+       *        on the range `array[l, r]` (bounds are inclusive).
+       * 
+       * @param l Left bound of query (inclusive)
+       * @param r Right bound of query (inclusive)
+       * @return Type Result of the query based on `combine`
+       */
+      Type range_query (int l, int r)
+      { return _range_query_impl(0, 0, base_size - 1, l, r); }
+
+      /**
+       * @brief Custom point update in segment tree.
+       * 
+       * The implementation for this method can be added by the user if they would like
+       * to perform updates in a different sense from the norm.
+       * 
+       * @tparam ParamTypes Types of parameters that will be passed to the update implementation
+       * @param position Index to be updated
+       * @param params Parameter list required by custom update implementation
+       */
+      template <typename... ParamTypes>
+      void custom_point_update (int position, const ParamTypes&... params)
+      { _custom_point_update_impl(0, 0, base_size - 1, position, params...); }
+
+      /**
+       * @brief Custom point query in segment tree.
+       * 
+       * The implementation for this method can be added by the user if they would like
+       * to perform updates in a different sense from the norm.
+       * 
+       * @tparam ParamTypes Types of parameters that will be passed to the query implementation
+       * @param position Index to be queried
+       * @param params Parameter list required by custom query implementation
+       */
+      template <typename... ParamTypes>
+      Type custom_point_query (int position, const ParamTypes&... params)
+      { _custom_point_query_impl(0, 0, base_size - 1, position, params...); }
+
+      /**
+       * @brief Custom query/update in segment tree.
+       * 
+       * The implementation for this method can be added by the user if they would like
+       * to perform queries in a different sense from the norm. It is very flexible with
+       * the requirements of the user.
+       * 
+       * This function is flexible in the sense that you can copy the body multiple times and rename
+       * it to achieve different functionality as per liking.
+       * 
+       * Operations like `lazy propagation` or `beats` or `persistence` have not been implemented, and
+       * have been left to the user to do as per their liking. It can be done very easily by manipulating
+       * the body of the _custom_query_impl method (and/or creating copies of this function with different
+       * names for different purposes).
+       * 
+       * @tparam ParamTypes Types of parameters that will be passed to the query/update implementation
+       * @param params Parameter list required by custom query/update implementation
+       */
+      template <typename ReturnType, typename... ParamTypes>
+      ReturnType custom_query (const ParamTypes&... params)
+      { return _custom_query_impl <ReturnType> (0, 0, base_size - 1, params...); }
+
+    private:
+      /**
+       * @brief Returns the index of the left child given the parent index based on
+       *        chosen tree_memory_layout
+       * 
+       * @param v Index of parent
+       * @param tl Left bound of parent
+       * @param tr Right bound of parent
+       * @return int Index of left child of parent
+       */
+      int _get_leftchild (int v, [[maybe_unused]] int tl, [[maybe_unused]] int tr) {
+        if constexpr (impl_type == tree_memory_layout::binary)
+          return 2 * v + 1;
+        else
+          return v + 1;
+      }
+
+      /**
+       * @brief Returns the index of the right child given the parent index based on
+       *        chosen tree_memory_layout
+       * 
+       * @param v Index of parent
+       * @param tl Left bound of parent
+       * @param tr Right bound of parent
+       * @return int Index of right child of parent
+       */
+      int _get_rightchild (int v, [[maybe_unused]] int tl, [[maybe_unused]] int tr) {
+        if constexpr (impl_type == tree_memory_layout::binary)
+          return 2 * v + 2;
+        else {
+          int tm = (tl + tr) / 2;
+          int node_count = tm - tl + 1;
+          return v + 2 * node_count;
+        }
+      }
+
+      /**
+       * @brief Internal function to build the segment tree
+       * 
+       * @param v Index of node where the segment tree starts to build
+       * @param tl Left bound of node
+       * @param tr Right bound of node
+       */
+      void _build_impl (int v, int tl, int tr) {
+        if (tl == tr) {
+          tree[v] = base_ref[tl];
+          return;
+        }
+
+        int tm = (tl + tr) / 2;
+        int lchild = _get_leftchild(v, tl, tr);
+        int rchild = _get_rightchild(v, tl, tr);
+
+        _build_impl(lchild, tl, tm);
+        _build_impl(rchild, tm + 1, tr);
+        
+        tree[v] = combine(tree[lchild], tree[rchild]);
+      }
+
+      /**
+       * @brief Internal implementation of point_update
+       * 
+       * @param v Current node index
+       * @param tl Current node left bound
+       * @param tr Current node right bound
+       * @param position Index to be updated
+       * @param value Value to be set at `position`
+       */
+      void _point_update_impl (int v, int tl, int tr, int position, const Type& value) {
+        if (tl == tr) {
+          tree[v] = value;
+          return;
+        }
+
+        int tm = (tl + tr) / 2;
+        int lchild = _get_leftchild(v, tl, tr);
+        int rchild = _get_rightchild(v, tl, tr);
+        
+        // Since we need to only update a single index, we choose the correct
+        // "side" of the segment tree to traverse to at each step
+        if (position <= tm)
+          _point_update_impl(lchild, tl, tm, position, value);
+        else
+          _point_update_impl(rchild, tm + 1, tr, position, value);
+        
+        tree[v] = combine(tree[lchild], tree[rchild]);
+      }
+
+      /**
+       * @brief Internal implementation of point_query
+       * 
+       * @param v Current node index
+       * @param tl Current node left bound
+       * @param tr Current node right bound
+       * @param position Index to be updated
+       * @return Type Value to be set at `position`
+       */
+      Type _point_query_impl (int v, int tl, int tr, int position) {
+        if (tl == tr)
+          return tree[v];
+        
+        int tm = (tl + tr) / 2;
+        int lchild = _get_leftchild(v, tl, tr);
+        int rchild = _get_rightchild(v, tl, tr);
+        
+        // Since we need to only update a single index, we choose the correct
+        // "side" of the segment tree to traverse to at each step
+        if (position <= tm)
+          return _point_query_impl(lchild, tl, tm, position);
+        else
+          return _point_query_impl(rchild, tm + 1, tr, position);
+      }
+
+      /**
+       * @brief Internal implementation of range_query
+       * 
+       * @param v Current node index
+       * @param tl Current node left bound
+       * @param tr Current node right bound
+       * @param l Current query left bound
+       * @param r Current query right bound
+       * @return Type Result of the query
+       */
+      Type _range_query_impl (int v, int tl, int tr, int l, int r) {
+        // We are out of bounds in our search
+        // Return a sentinel value which must be defaulted in the constuctor of Type
+        if (l > r)
+          return {};
+        
+        // We have found the correct range for the query
+        // Return the value at current node because it's not required to process further
+        if (tl == l and tr == r)
+          return tree[v];
+        
+        int tm = (tl + tr) / 2;
+        int lchild = _get_leftchild(v, tl, tr);
+        int rchild = _get_rightchild(v, tl, tr);
+
+        // We have not yet found the correct range for the query
+        // Get results of left child and right child and combine
+        Type lval = _range_query_impl(lchild, tl, tm, l, std::min(r, tm));
+        Type rval = _range_query_impl(rchild, tm + 1, tr, std::max(l, tm + 1), r);
+        
+        return combine(lval, rval);
+      }
+
+      /**
+       * @brief Internal implementation of custom_point_update
+       * 
+       * Note that you need to change the definition of this function if you're passing
+       * any variadic argument list in custom_point_update
+       * 
+       * @param v Current node index
+       * @param tl Current node left bound
+       * @param tr Current node right bound
+       * @param position Index to be updated
+       */
+      void _custom_point_update_impl (int v, int tl, int tr, int position) {
+        if (tl == tr) {
+          throw std::runtime_error("undefined implementation");
+          return;
+        }
+
+        int tm = (tl + tr) / 2;
+        int lchild = _get_leftchild(v, tl, tr);
+        int rchild = _get_rightchild(v, tl, tr);
+
+        // Since we need to only update a single index, we choose the correct
+        // "side" of the segment tree to traverse to at each step
+        if (position <= tm)
+          _custom_point_update_impl(lchild, tl, tm, position);
+        else
+          _custom_point_update_impl(rchild, tm + 1, tr, position);
+        
+        tree[v] = combine(tree[lchild], tree[rchild]);
+      }
+
+      /**
+       * @brief Internal implementation of custom_point_query
+       * 
+       * Note that you need to change the definition of this function if you're passing
+       * any variadic argument list in custom_point_query
+       * 
+       * @param v Current node index
+       * @param tl Current node left bound
+       * @param tr Current node right bound
+       * @param position Index to be queried
+       * @return Type Result of the query
+       */
+      Type _custom_point_query_impl (int v, int tl, int tr, int position) {
+        if (tl == tr) {
+          throw std::runtime_error("undefined implementation");
+          return {};
+        }
+
+        int tm = (tl + tr) / 2;
+        int lchild = _get_leftchild(v, tl, tr);
+        int rchild = _get_rightchild(v, tl, tr);
+
+        // Since we need to only update a single index, we choose the correct
+        // "side" of the segment tree to traverse to at each step
+        if (position <= tm)
+          return _custom_point_query_impl(lchild, tl, tm, position);
+        else
+          return _custom_point_query_impl(rchild, tm + 1, tr, position);
+      }
+
+      /**
+       * @brief Internal implementation of custom_query
+       * 
+       * The user can create multiple copies with different names for this function and make
+       * calls accordingly. Read the documentation for custom_query above.
+       * 
+       * @tparam ReturnType Return type of the custom query/update
+       * @param v Current node index
+       * @param tl Current node left bound
+       * @param tr Current node right bound
+       * @return ReturnType Return value of the custom query/update
+       */
+      template <typename ReturnType>
+      ReturnType _custom_query_impl (int v, int tl, int tr) {
+        if (tl == tr) {
+          throw std::runtime_error("undefined implementation");
+          return ReturnType{};
+        }
+        
+        int tm = (tl + tr) / 2;
+        int lchild = _get_leftchild(v, tl, tr);
+        int rchild = _get_rightchild(v, tl, tr);
+
+        // Change functionality as per liking
+        if (true)
+          return _custom_query_impl <ReturnType> (lchild, tl, tm);
+        else
+          return _custom_query_impl <ReturnType> (rchild, tm + 1, tr);
+      }
+  };
+};

--- a/code/data_structures/test/tree/segment_tree/test_generic_segment_tree.cpp
+++ b/code/data_structures/test/tree/segment_tree/test_generic_segment_tree.cpp
@@ -1,0 +1,126 @@
+#include <bits/stdc++.h>
+
+// Note that the below line includes a translation unit and not header file
+
+#include "../../../src/tree/segment_tree/generic_segment_tree.cpp"
+
+#define ASSERT(value, expected_value, message)                   \
+{                                                                \
+  if (value != expected_value)                                   \
+    std::cerr << "[assertion failed]\n"                          \
+              << "   Line: " << __LINE__ << '\n'                 \
+              << "   File: " << __FILE__ << '\n'                 \
+              << "Message: " << message << std::endl;            \
+  else                                                           \
+    std::cerr << "[assertion passed]: " << message << std::endl; \
+}
+
+/**
+ * This program tests the generic segment tree implementation that can be found in the include location above.
+ * The implementation requires C++20 in order to compile.
+ * 
+ * Compilation: g++ test_generic_segment_tree.cpp -o test_generic_segment_tree -Wall -Wextra -pedantic -std=c++20 -O3
+ */
+
+constexpr bool is_multitest = false;
+constexpr int32_t inf32 = int32_t(1) << 30;
+constexpr int64_t inf64 = int64_t(1) << 60;
+
+void test () {
+  std::vector <int> values = { 1, 2, 3, 4, 5 };
+  int n = values.size();
+
+  arrow::segment_tree <int> binary_tree_sum (n, values, [] (auto l, auto r) {
+    return l + r;
+  });
+
+  arrow::segment_tree <int, arrow::tree_memory_layout::euler_tour> euler_tour_tree_sum (n, values, [] (auto l, auto r) {
+    return l + r;
+  });
+
+  ASSERT(binary_tree_sum.range_query(0, 4), 15, "binary_tree_sum.range_query(0, 4) == 15");
+  ASSERT(binary_tree_sum.range_query(1, 2),  5, "binary_tree_sum.range_query(1, 2) == 5");
+  ASSERT(binary_tree_sum.range_query(4, 4),  5, "binary_tree_sum.range_query(4, 4) == 5");
+  ASSERT(binary_tree_sum.range_query(2, 4), 12, "binary_tree_sum.range_query(2, 4) == 12");
+  ASSERT(binary_tree_sum.range_query(0, 3), 10, "binary_tree_sum.range_query(0, 3) == 10");
+
+  ASSERT(euler_tour_tree_sum.range_query(0, 4), 15, "euler_tour_tree_sum.range_query(0, 4) == 15");
+  ASSERT(euler_tour_tree_sum.range_query(1, 2),  5, "euler_tour_tree_sum.range_query(1, 2) == 5");
+  ASSERT(euler_tour_tree_sum.range_query(4, 4),  5, "euler_tour_tree_sum.range_query(4, 4) == 5");
+  ASSERT(euler_tour_tree_sum.range_query(2, 4), 12, "euler_tour_tree_sum.range_query(2, 4) == 12");
+  ASSERT(euler_tour_tree_sum.range_query(0, 3), 10, "euler_tour_tree_sum.range_query(0, 3) == 10");
+
+  binary_tree_sum.point_update(2, 10);
+  euler_tour_tree_sum.point_update(0, 8);
+
+  ASSERT(binary_tree_sum.point_query(2), 10, "binary_tree_sum.point_query(2) == 10");
+  ASSERT(binary_tree_sum.range_query(1, 3), 16, "binary_tree_sum.range_query(1, 3) == 16");
+  ASSERT(binary_tree_sum.range_query(0, 4), 22, "binary_tree_sum.range_query(0, 4) == 22");
+
+  ASSERT(euler_tour_tree_sum.point_query(0), 8, "euler_tour_sum.point_query(0) == 8");
+  ASSERT(euler_tour_tree_sum.range_query(1, 3), 9, "euler_tour_sum.range_query(1, 3) == 9");
+  ASSERT(euler_tour_tree_sum.range_query(0, 4), 22, "euler_tour_sum.range_query(0, 4) == 22");
+
+  values = {
+    2, -4, 3, -1, 4, 1, -2, 5
+  };
+  n = values.size();
+
+  struct node {
+    int value;
+    int max_prefix;
+    int max_suffix;
+    int max_subsegment;
+
+    node (int v = 0) {
+      int m = std::max(v, 0);
+
+      value = v;
+      max_prefix = m;
+      max_suffix = m;
+      max_subsegment = m;
+    }
+  };
+
+  std::vector <node> node_values;
+
+  for (auto i: values) {
+    node_values.push_back(node(i));
+  }
+  
+  arrow::segment_tree <node> binary_tree_max_subsegment (n, node_values, [] (auto l, auto r) {
+    node result;
+    result.value = l.value + r.value;
+    result.max_prefix = std::max(l.max_prefix, l.value + r.max_prefix);
+    result.max_suffix = std::max(l.max_suffix + r.value, r.max_suffix);
+    result.max_subsegment = std::max({l.max_subsegment, r.max_subsegment, l.max_suffix + r.max_prefix});
+    return result;
+  });
+
+  ASSERT(binary_tree_max_subsegment.range_query(0, 7).value, 8, "binary_tree_max_subsegment.range_query(0, 7).value == 8");
+  ASSERT(binary_tree_max_subsegment.range_query(3, 5).value, 4, "binary_tree_max_subsegment.range_query(3, 5).value == 4");
+  ASSERT(binary_tree_max_subsegment.range_query(2, 6).value, 5, "binary_tree_max_subsegment.range_query(2, 6).value == 5");
+  ASSERT(binary_tree_max_subsegment.range_query(1, 4).value, 2, "binary_tree_max_subsegment.range_query(1, 4).value == 2");
+  ASSERT(binary_tree_max_subsegment.range_query(7, 7).value, 5, "binary_tree_max_subsegment.range_query(7, 7).value == 5");
+  ASSERT(binary_tree_max_subsegment.range_query(0, 4).value, 4, "binary_tree_max_subsegment.range_query(0, 4).value == 4");
+
+  binary_tree_max_subsegment.point_update(5, 4);
+  binary_tree_max_subsegment.point_update(3, -7);
+  binary_tree_max_subsegment.point_update(1, 3);
+  
+  ASSERT(binary_tree_max_subsegment.range_query(0, 7).value, 12, "binary_tree_max_subsegment.range_query(0, 7).value == 12");
+  ASSERT(binary_tree_max_subsegment.range_query(3, 5).value, 1, "binary_tree_max_subsegment.range_query(3, 5).value == 1");
+  ASSERT(binary_tree_max_subsegment.range_query(2, 6).value, 2, "binary_tree_max_subsegment.range_query(2, 6).value == 2");
+  ASSERT(binary_tree_max_subsegment.range_query(1, 4).value, 3, "binary_tree_max_subsegment.range_query(1, 4).value == 3");
+  ASSERT(binary_tree_max_subsegment.range_query(7, 7).value, 5, "binary_tree_max_subsegment.range_query(7, 7).value == 5");
+  ASSERT(binary_tree_max_subsegment.range_query(0, 4).value, 5, "binary_tree_max_subsegment.range_query(0, 4).value == 5");
+}
+
+int main () {
+  std::ios::sync_with_stdio(false);
+  std::cin.tie(nullptr);
+
+  test();
+
+  return 0;
+}

--- a/code/data_structures/test/tree/segment_tree/test_generic_segment_tree.cpp
+++ b/code/data_structures/test/tree/segment_tree/test_generic_segment_tree.cpp
@@ -1,4 +1,6 @@
-#include <bits/stdc++.h>
+#include <algorithm>
+#include <iostream>
+#include <vector>
 
 // Note that the below line includes a translation unit and not header file
 
@@ -30,36 +32,36 @@ void test () {
   std::vector <int> values = { 1, 2, 3, 4, 5 };
   int n = values.size();
 
-  arrow::segment_tree <int> binary_tree_sum (n, values, [] (auto l, auto r) {
+  arrow::SegmentTree <int> binaryTreeSum (n, values, [] (auto l, auto r) {
     return l + r;
   });
 
-  arrow::segment_tree <int, arrow::tree_memory_layout::euler_tour> euler_tour_tree_sum (n, values, [] (auto l, auto r) {
+  arrow::SegmentTree <int, arrow::TreeMemoryLayout::EulerTour> eulerTourTreeSum (n, values, [] (auto l, auto r) {
     return l + r;
   });
 
-  ASSERT(binary_tree_sum.range_query(0, 4), 15, "binary_tree_sum.range_query(0, 4) == 15");
-  ASSERT(binary_tree_sum.range_query(1, 2),  5, "binary_tree_sum.range_query(1, 2) == 5");
-  ASSERT(binary_tree_sum.range_query(4, 4),  5, "binary_tree_sum.range_query(4, 4) == 5");
-  ASSERT(binary_tree_sum.range_query(2, 4), 12, "binary_tree_sum.range_query(2, 4) == 12");
-  ASSERT(binary_tree_sum.range_query(0, 3), 10, "binary_tree_sum.range_query(0, 3) == 10");
+  ASSERT(binaryTreeSum.rangeQuery(0, 4), 15, "binaryTreeSum.rangeQuery(0, 4) == 15");
+  ASSERT(binaryTreeSum.rangeQuery(1, 2),  5, "binaryTreeSum.rangeQuery(1, 2) == 5");
+  ASSERT(binaryTreeSum.rangeQuery(4, 4),  5, "binaryTreeSum.rangeQuery(4, 4) == 5");
+  ASSERT(binaryTreeSum.rangeQuery(2, 4), 12, "binaryTreeSum.rangeQuery(2, 4) == 12");
+  ASSERT(binaryTreeSum.rangeQuery(0, 3), 10, "binaryTreeSum.rangeQuery(0, 3) == 10");
 
-  ASSERT(euler_tour_tree_sum.range_query(0, 4), 15, "euler_tour_tree_sum.range_query(0, 4) == 15");
-  ASSERT(euler_tour_tree_sum.range_query(1, 2),  5, "euler_tour_tree_sum.range_query(1, 2) == 5");
-  ASSERT(euler_tour_tree_sum.range_query(4, 4),  5, "euler_tour_tree_sum.range_query(4, 4) == 5");
-  ASSERT(euler_tour_tree_sum.range_query(2, 4), 12, "euler_tour_tree_sum.range_query(2, 4) == 12");
-  ASSERT(euler_tour_tree_sum.range_query(0, 3), 10, "euler_tour_tree_sum.range_query(0, 3) == 10");
+  ASSERT(eulerTourTreeSum.rangeQuery(0, 4), 15, "eulerTourTreeSum.rangeQuery(0, 4) == 15");
+  ASSERT(eulerTourTreeSum.rangeQuery(1, 2),  5, "eulerTourTreeSum.rangeQuery(1, 2) == 5");
+  ASSERT(eulerTourTreeSum.rangeQuery(4, 4),  5, "eulerTourTreeSum.rangeQuery(4, 4) == 5");
+  ASSERT(eulerTourTreeSum.rangeQuery(2, 4), 12, "eulerTourTreeSum.rangeQuery(2, 4) == 12");
+  ASSERT(eulerTourTreeSum.rangeQuery(0, 3), 10, "eulerTourTreeSum.rangeQuery(0, 3) == 10");
 
-  binary_tree_sum.point_update(2, 10);
-  euler_tour_tree_sum.point_update(0, 8);
+  binaryTreeSum.pointUpdate(2, 10);
+  eulerTourTreeSum.pointUpdate(0, 8);
 
-  ASSERT(binary_tree_sum.point_query(2), 10, "binary_tree_sum.point_query(2) == 10");
-  ASSERT(binary_tree_sum.range_query(1, 3), 16, "binary_tree_sum.range_query(1, 3) == 16");
-  ASSERT(binary_tree_sum.range_query(0, 4), 22, "binary_tree_sum.range_query(0, 4) == 22");
+  ASSERT(binaryTreeSum.pointQuery(2), 10, "binaryTreeSum.pointQuery(2) == 10");
+  ASSERT(binaryTreeSum.rangeQuery(1, 3), 16, "binaryTreeSum.rangeQuery(1, 3) == 16");
+  ASSERT(binaryTreeSum.rangeQuery(0, 4), 22, "binaryTreeSum.rangeQuery(0, 4) == 22");
 
-  ASSERT(euler_tour_tree_sum.point_query(0), 8, "euler_tour_sum.point_query(0) == 8");
-  ASSERT(euler_tour_tree_sum.range_query(1, 3), 9, "euler_tour_sum.range_query(1, 3) == 9");
-  ASSERT(euler_tour_tree_sum.range_query(0, 4), 22, "euler_tour_sum.range_query(0, 4) == 22");
+  ASSERT(eulerTourTreeSum.pointQuery(0), 8, "euler_tour_sum.pointQuery(0) == 8");
+  ASSERT(eulerTourTreeSum.rangeQuery(1, 3), 9, "euler_tour_sum.rangeQuery(1, 3) == 9");
+  ASSERT(eulerTourTreeSum.rangeQuery(0, 4), 22, "euler_tour_sum.rangeQuery(0, 4) == 22");
 
   values = {
     2, -4, 3, -1, 4, 1, -2, 5
@@ -68,17 +70,17 @@ void test () {
 
   struct node {
     int value;
-    int max_prefix;
-    int max_suffix;
-    int max_subsegment;
+    int maxPrefix;
+    int maxSuffix;
+    int maxSubsegment;
 
     node (int v = 0) {
       int m = std::max(v, 0);
 
       value = v;
-      max_prefix = m;
-      max_suffix = m;
-      max_subsegment = m;
+      maxPrefix = m;
+      maxSuffix = m;
+      maxSubsegment = m;
     }
   };
 
@@ -88,32 +90,32 @@ void test () {
     node_values.push_back(node(i));
   }
   
-  arrow::segment_tree <node> binary_tree_max_subsegment (n, node_values, [] (auto l, auto r) {
+  arrow::SegmentTree <node> binaryTreeMaxSubsegment (n, node_values, [] (auto l, auto r) {
     node result;
     result.value = l.value + r.value;
-    result.max_prefix = std::max(l.max_prefix, l.value + r.max_prefix);
-    result.max_suffix = std::max(l.max_suffix + r.value, r.max_suffix);
-    result.max_subsegment = std::max({l.max_subsegment, r.max_subsegment, l.max_suffix + r.max_prefix});
+    result.maxPrefix = std::max(l.maxPrefix, l.value + r.maxPrefix);
+    result.maxSuffix = std::max(l.maxSuffix + r.value, r.maxSuffix);
+    result.maxSubsegment = std::max({l.maxSubsegment, r.maxSubsegment, l.maxSuffix + r.maxPrefix});
     return result;
   });
 
-  ASSERT(binary_tree_max_subsegment.range_query(0, 7).value, 8, "binary_tree_max_subsegment.range_query(0, 7).value == 8");
-  ASSERT(binary_tree_max_subsegment.range_query(3, 5).value, 4, "binary_tree_max_subsegment.range_query(3, 5).value == 4");
-  ASSERT(binary_tree_max_subsegment.range_query(2, 6).value, 5, "binary_tree_max_subsegment.range_query(2, 6).value == 5");
-  ASSERT(binary_tree_max_subsegment.range_query(1, 4).value, 2, "binary_tree_max_subsegment.range_query(1, 4).value == 2");
-  ASSERT(binary_tree_max_subsegment.range_query(7, 7).value, 5, "binary_tree_max_subsegment.range_query(7, 7).value == 5");
-  ASSERT(binary_tree_max_subsegment.range_query(0, 4).value, 4, "binary_tree_max_subsegment.range_query(0, 4).value == 4");
+  ASSERT(binaryTreeMaxSubsegment.rangeQuery(0, 7).value, 8, "binaryTreeMaxSubsegment.rangeQuery(0, 7).value == 8");
+  ASSERT(binaryTreeMaxSubsegment.rangeQuery(3, 5).value, 4, "binaryTreeMaxSubsegment.rangeQuery(3, 5).value == 4");
+  ASSERT(binaryTreeMaxSubsegment.rangeQuery(2, 6).value, 5, "binaryTreeMaxSubsegment.rangeQuery(2, 6).value == 5");
+  ASSERT(binaryTreeMaxSubsegment.rangeQuery(1, 4).value, 2, "binaryTreeMaxSubsegment.rangeQuery(1, 4).value == 2");
+  ASSERT(binaryTreeMaxSubsegment.rangeQuery(7, 7).value, 5, "binaryTreeMaxSubsegment.rangeQuery(7, 7).value == 5");
+  ASSERT(binaryTreeMaxSubsegment.rangeQuery(0, 4).value, 4, "binaryTreeMaxSubsegment.rangeQuery(0, 4).value == 4");
 
-  binary_tree_max_subsegment.point_update(5, 4);
-  binary_tree_max_subsegment.point_update(3, -7);
-  binary_tree_max_subsegment.point_update(1, 3);
+  binaryTreeMaxSubsegment.pointUpdate(5, 4);
+  binaryTreeMaxSubsegment.pointUpdate(3, -7);
+  binaryTreeMaxSubsegment.pointUpdate(1, 3);
   
-  ASSERT(binary_tree_max_subsegment.range_query(0, 7).value, 12, "binary_tree_max_subsegment.range_query(0, 7).value == 12");
-  ASSERT(binary_tree_max_subsegment.range_query(3, 5).value, 1, "binary_tree_max_subsegment.range_query(3, 5).value == 1");
-  ASSERT(binary_tree_max_subsegment.range_query(2, 6).value, 2, "binary_tree_max_subsegment.range_query(2, 6).value == 2");
-  ASSERT(binary_tree_max_subsegment.range_query(1, 4).value, 3, "binary_tree_max_subsegment.range_query(1, 4).value == 3");
-  ASSERT(binary_tree_max_subsegment.range_query(7, 7).value, 5, "binary_tree_max_subsegment.range_query(7, 7).value == 5");
-  ASSERT(binary_tree_max_subsegment.range_query(0, 4).value, 5, "binary_tree_max_subsegment.range_query(0, 4).value == 5");
+  ASSERT(binaryTreeMaxSubsegment.rangeQuery(0, 7).value, 12, "binaryTreeMaxSubsegment.rangeQuery(0, 7).value == 12");
+  ASSERT(binaryTreeMaxSubsegment.rangeQuery(3, 5).value, 1, "binaryTreeMaxSubsegment.rangeQuery(3, 5).value == 1");
+  ASSERT(binaryTreeMaxSubsegment.rangeQuery(2, 6).value, 2, "binaryTreeMaxSubsegment.rangeQuery(2, 6).value == 2");
+  ASSERT(binaryTreeMaxSubsegment.rangeQuery(1, 4).value, 3, "binaryTreeMaxSubsegment.rangeQuery(1, 4).value == 3");
+  ASSERT(binaryTreeMaxSubsegment.rangeQuery(7, 7).value, 5, "binaryTreeMaxSubsegment.rangeQuery(7, 7).value == 5");
+  ASSERT(binaryTreeMaxSubsegment.rangeQuery(0, 4).value, 5, "binaryTreeMaxSubsegment.rangeQuery(0, 4).value == 5");
 }
 
 int main () {


### PR DESCRIPTION
**Contribution for Hacktoberfest :rocket:**

**Fixes issue:**
<!-- [Mention the issue number it fixes or add the details of the changes if it doesn't has a specific issue. -->


**Changes:**
<!-- Add here what changes were made in this pull request. -->

- Generic Segment Tree Implementation
- Tests for Generic Segment Tree

Added generic implementation of a [Segment Tree](https://en.wikipedia.org/wiki/Segment_tree). It supports operations like point queries, point updates, range queries and range updates. Implementation of lazy propagation and other fancy segment tree techniques can be done by the user as per their liking in custom_query function.

This implementation supports two memory layouts for the segment tree: binary (uses `4.n` memory) and euler_tour (uses `2.n` memory) and can be used as shown below.

```cpp
// use binary tree memory layout
arrow::segment_tree <int> tree (n, values, [] (auto l, auto r) {
    return l + r;
}); // defaults to arrow::tree_memory_layout::binary

// use euler tour memory layout
arrow::segment_tree <int, arrow::tree_memory_layout::euler_tour> tree (n, values, [] (auto l, auto r) {
    return l + r;
});
```

**Testing**

Compile the `test_generic_segment_tree.cpp` file using appropriate flags. Here's what I used:
`g++ test_generic_segment_tree.cpp -o test_generic_segment_tree -Wall -Wextra -pedantic -std=c++20 -O3`

Run the test program and compare the results.

```
$ ./test_generic_segment_tree

[assertion passed]: binaryTreeSum.rangeQuery(0, 4) == 15
[assertion passed]: binaryTreeSum.rangeQuery(1, 2) == 5
[assertion passed]: binaryTreeSum.rangeQuery(4, 4) == 5
[assertion passed]: binaryTreeSum.rangeQuery(2, 4) == 12
[assertion passed]: binaryTreeSum.rangeQuery(0, 3) == 10
[assertion passed]: eulerTourTreeSum.rangeQuery(0, 4) == 15
[assertion passed]: eulerTourTreeSum.rangeQuery(1, 2) == 5
[assertion passed]: eulerTourTreeSum.rangeQuery(4, 4) == 5
[assertion passed]: eulerTourTreeSum.rangeQuery(2, 4) == 12
[assertion passed]: eulerTourTreeSum.rangeQuery(0, 3) == 10
[assertion passed]: binaryTreeSum.pointQuery(2) == 10
[assertion passed]: binaryTreeSum.rangeQuery(1, 3) == 16
[assertion passed]: binaryTreeSum.rangeQuery(0, 4) == 22
[assertion passed]: euler_tour_sum.pointQuery(0) == 8
[assertion passed]: euler_tour_sum.rangeQuery(1, 3) == 9
[assertion passed]: euler_tour_sum.rangeQuery(0, 4) == 22
[assertion passed]: binaryTreeMaxSubsegment.rangeQuery(0, 7).value == 8
[assertion passed]: binaryTreeMaxSubsegment.rangeQuery(3, 5).value == 4
[assertion passed]: binaryTreeMaxSubsegment.rangeQuery(2, 6).value == 5
[assertion passed]: binaryTreeMaxSubsegment.rangeQuery(1, 4).value == 2
[assertion passed]: binaryTreeMaxSubsegment.rangeQuery(7, 7).value == 5
[assertion passed]: binaryTreeMaxSubsegment.rangeQuery(0, 4).value == 4
[assertion passed]: binaryTreeMaxSubsegment.rangeQuery(0, 7).value == 12
[assertion passed]: binaryTreeMaxSubsegment.rangeQuery(3, 5).value == 1
[assertion passed]: binaryTreeMaxSubsegment.rangeQuery(2, 6).value == 2
[assertion passed]: binaryTreeMaxSubsegment.rangeQuery(1, 4).value == 3
[assertion passed]: binaryTreeMaxSubsegment.rangeQuery(7, 7).value == 5
[assertion passed]: binaryTreeMaxSubsegment.rangeQuery(0, 4).value == 5
```

<!-- Make sure to look at the Style Guide for your language in guides/coding_style/language_name:

     https://github.com/OpenGenus/cosmos/tree/master/guides/coding_style

     Note: A coding style guide may not exist for your language, since this is still in beta.
-->

<!-- Make sure to look at the Documentation Style Guide in guides/documentation.md:

     https://github.com/OpenGenus/cosmos/blob/master/guides/documentation_guide.md

     The document style guide may not apply for your algorithm category, you must also look at specified guide under all of the directory in the category, e.g., for project euler:

     https://github.com/OpenGenus/cosmos/blob/master/code/online_challenges/src/project_euler/documentation_guide.md
-->
